### PR TITLE
Move "Kratix complements" nav and collapse nav bar

### DIFF
--- a/.github/workflows/deploy-to-ghpages.yml
+++ b/.github/workflows/deploy-to-ghpages.yml
@@ -1,0 +1,42 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["gh-pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy-to-ghpages.yml
+++ b/.github/workflows/deploy-to-ghpages.yml
@@ -1,5 +1,5 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: pages build and deployment
 
 on:
   # Runs on pushes targeting the default branch
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -40,3 +39,13 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+        
+  update-search:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Algolia
+        uses: addnab/docker-run-action@v3
+        with:
+          image: algolia/docsearch-scraper
+          options: -env=APPLICATION_ID=${ALGOLIA_APP_ID} --env=API_KEY=${ALGOLIA_API_KEY} --env "CONFIG=$(cat ./algolia-config.json | jq -r tostring)"

--- a/.github/workflows/deploy-to-ghpages.yml
+++ b/.github/workflows/deploy-to-ghpages.yml
@@ -44,8 +44,13 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Update Algolia
-        uses: addnab/docker-run-action@v3
-        with:
-          image: algolia/docsearch-scraper
-          options: -env=APPLICATION_ID=${ALGOLIA_APP_ID} --env=API_KEY=${ALGOLIA_API_KEY} --env "CONFIG=$(cat ./algolia-config.json | jq -r tostring)"
+      - name: Get the content of algolia.json as config
+        id: algolia_config
+        run: echo "::set-output name=config::$(echo algolia-config.json | jq -r tostring)"
+
+      - name: Push indices to Algolia
+        uses: signcl/docsearch-scraper-action@master
+        env:
+          APPLICATION_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          CONFIG: ${{ steps.algolia_config.outputs.config }}

--- a/.github/workflows/deploy-to-ghpages.yml
+++ b/.github/workflows/deploy-to-ghpages.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: gh-pages
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact
@@ -39,7 +41,7 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-        
+
   update-search:
     needs: deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,6 +35,6 @@ jobs:
       - name: Push indices to Algolia
         uses: signcl/docsearch-scraper-action@master
         env:
-          APPLICATION_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          APPLICATION_ID: ${{ vars.ALGOLIA_APP_ID }}
           API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           CONFIG: ${{ steps.algolia_config.outputs.config }}

--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -31,7 +31,7 @@ jobs:
           ref: main
       - name: Get the content of algolia.json as config
         id: algolia_config
-        run: echo "::set-output name=config::$(echo algolia-config.json | jq -r tostring)"
+        run: echo "::set-output name=config::$(cat algolia-config.json | jq -r tostring)"
       - name: Push indices to Algolia
         uses: signcl/docsearch-scraper-action@master
         env:

--- a/.github/workflows/update-algolia.yml
+++ b/.github/workflows/update-algolia.yml
@@ -1,10 +1,11 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: pages build and deployment
+name: update algolia
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["gh-pages"]
+  workflow_run:
+    workflows: [pages-build-deployment]
+    types:
+      - completed
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -22,34 +23,15 @@ concurrency:
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: gh-pages
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          # Upload entire repository
-          path: '.'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
-
-  update-search:
-    needs: deploy
-    runs-on: ubuntu-latest
-    steps:
+          ref: main
       - name: Get the content of algolia.json as config
         id: algolia_config
         run: echo "::set-output name=config::$(echo algolia-config.json | jq -r tostring)"
-
       - name: Push indices to Algolia
         uses: signcl/docsearch-scraper-action@master
         env:

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -1,0 +1,49 @@
+{
+  "index_name": "kratix_io",
+  "start_urls": [
+    "https://kratix.io"
+  ],
+  "sitemap_urls": [
+    "https://kratix.io/sitemap.xml"
+  ],
+  "sitemap_alternate_links": true,
+  "stop_urls": [
+    "/blog",
+    "/workshop",
+    "/marketplace",
+    "/docs/events"
+  ],
+  "selectors": {
+    "lvl0": {
+      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "type": "xpath",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": "header h1",
+    "lvl2": "article h2",
+    "lvl3": "article h3",
+    "lvl4": "article h4",
+    "lvl5": "article h5, article td:first-child",
+    "lvl6": "article h6",
+    "text": "article p, article li, article td:last-child"
+  },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  }
+}

--- a/docs/main/01-intro.md
+++ b/docs/main/01-intro.md
@@ -13,7 +13,7 @@ Check out a video overview of our product:
 ### Using Kratix to build your platform you can:
 
 * use GitOps workflow with Flux and familiar Kubernetes-native constructs.
-* co-create capabilities by providing a clear contract between application and platform teams through the definition and creation of “Promises”. Learn more about Kratix Promises [here](./guides/writing-a-promise).
+* co-create capabilities by providing a clear contract between application and platform teams through the definition and creation of _Promises_. Learn more about Kratix Promises [here](./guides/writing-a-promise).
 * create a flexible platform with your paved paths as Promises.
 * evolve your platform easily as your business needs change.
 * start small on a laptop and expand to multi-team, multi-cluster, multi-region, and multi-cloud with a consistent API everywhere.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,6 +140,14 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
         additionalLanguages: ['shell-session']
+      },
+      algolia: {
+        // Algolia application ID
+        appId: 'HCC8KZQZAN',
+        // Public API key
+        apiKey: 'e6987ab7376144570f40e7355b648d8a',
+        indexName: 'kratix_io',
+        contextualSearch: true,
       }
     }),
 };


### PR DESCRIPTION
1. Move the ‘How Kratix Complements’ to the main level. It’s a frequent enough topic that Abby and I were thinking it should stand on its own.
1. Stop auto-expanding to docs menu. There are enough top level things that I feel like now it’s hard to scan and know where to go. Making this change will mean we have the default behaviour for docs for docusaurus. I would want to do this no matter what we decided to do for (1).