### PR TITLE
chore: update SKE docs to reflect Promise and Resource entities

### DIFF
--- a/docs/ske/01-backstage.mdx
+++ b/docs/ske/01-backstage.mdx
@@ -270,24 +270,67 @@ To access the documentation for the SKE actions, check the actions documentation
 on your Backstage instance, which is available on the `/create/actions`
 endpoint.
 
-## The Kratix Catalog Entity
+## The Kratix Catalog Entities
 
-Any catalog item with `type: "kratix-resource"` will be rendered using the
-`@syntasso/plugin-ske-frontend` plugin. To get all features of the plugin, your
-Component must include a few annotations and labels.
+The front-end plugin provides specific entity pages for both Kratix Promises and Kratix
+Resources. To get all features of the plugin, your Components must include a few fields
+and annotations so that the front-end plugin can render the right data.
 
-For example, considering a Promise that provides a Jenkins resource, the
-component definition would look like this:
+### Kratix Promise Entity
+
+Kratix Promises should be created with `type: "kratix-promise"` and a set of `kratix.io/`
+annotations which are used to convey metadata to the front-end plugin. The name, title
+and description should also be set to appropriate values.
+
+For example, considering a Promise that provides a Jenkins resource, the Component
+definition would look like this:
 
 ```yaml
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: KratixEntity
+  name: jenkins-promise # Name of the Promise Component
+  title: Jenkins Promise # Title to be displayed in Backstage
+  description: Jenkins as a Service # Description of the Promise
+  annotations:
+    kratix.io/promise-name: cicd # The Promise's metadata.name
+    kratix.io/api-name: Jenkins # The Kind of the resource provided by the Promise
+    kratix.io/api-group: marketplace.kratix.io # The Group of the resource provided by the Promise
+    kratix.io/status: |
+      {"message": "Some Status Message"}
+    kratix.io/backstage-promise-template: "create-jenkins" # Name of the Scaffolder template used to create the resource
+spec:
+  # highlight-next-line
+  type: kratix-promise
+  # remainder of the component spec...
+```
+
+### Kratix Resource Entity
+
+Kratix Resources should be created with `type: "kratix-resource"` and a set of `kratix.io/`
+annotations which are used to convey metadata to the front-end plugin. The name, title
+and description should also be set to appropriate values.
+
+The relationship between the Resource and the Promise can be displayed in the front-end
+plugin by adding a [`dependsOn` relation](https://backstage.io/docs/features/software-catalog/well-known-relations/#dependson-and-dependencyof)
+to the spec, which references the Promise Component via an
+[entity reference](https://backstage.io/docs/features/software-catalog/references#string-references).
+
+For example, considering a Jenkins resource requested on the Promise shown above, the
+Component definition for the Jenkins resource would look like this:
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
   #highlight-start
+  name: my-request-jenkins # Name of the Resource Component
+  title: "my-request Jenkins" # Title to be displayed in Backstage
+  description: "my-request Jenkins created via cicd Promise" # Description of the resource
   annotations:
     kratix.io/status: |
       {"message": "Some Status Message"}
+    kratix.io/promise-name: cicd # The Jenkins Promise's metadata.name
     kratix.io/group: "marketplace.example.io" # Promise API Group
     kratix.io/version: "v1alpha1" # Promise API Version
     kratix.io/kind: Jenkins # Promise API Kind
@@ -296,10 +339,11 @@ metadata:
     kratix.io/backstage-promise-template: "create-jenkins" # Name of the Scaffolder template used to create the resource
   #highlight-end
 spec:
-  # highlight-next-line
+  #highlight-start
   type: kratix-resource
-  # remainder of the component spec
-  lifecycle: production
-  owner: user:example
+  dependsOn:
+    - component:default/jenkins-promise # Entity reference for the Promise Component
+  #highlight-end
+  # remainder of the component spec...
   # ...
 ```

--- a/docs/ske/01-backstage.mdx
+++ b/docs/ske/01-backstage.mdx
@@ -270,6 +270,54 @@ To access the documentation for the SKE actions, check the actions documentation
 on your Backstage instance, which is available on the `/create/actions`
 endpoint.
 
+### Example: Using the `ske:configure-resource` action in a Template
+
+The `ske:configure-resource` action works by pushing a generated Resource Request manifest
+to a Git repository, and can be used in a Template to make these requests from within
+Backstage. The Template allows all Promise API fields to be filled in within Backstage.
+
+An outline of a Template for generating Jenkins Resource Requests is as follows:
+
+```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  description: Jenkins as a Service
+  name: jenkins-promise-template
+  title: Jenkins
+spec:
+  lifecycle: experimental
+  owner: kratix-platform
+  parameters:
+  - properties:
+      objname:
+        description: Name for the request in the platform cluster
+        title: Name
+        type: string
+      objnamespace:
+        description: Namespace for the request in the platform cluster
+        title: Namespace
+        type: string
+    required:
+    - objname
+    - objnamespace
+    title: Jenkins Instance Metadata
+  # other properties can be added here
+  steps:
+  - action: ske:configure-resource
+    id: ske-configure-resource
+    input:
+      manifest: |
+        apiVersion: marketplace.kratix.io/v1alpha1
+        kind: jenkins
+        metadata:
+          name: ${{ parameters.objname }}
+          namespace: ${{ parameters.objnamespace}}
+        spec: ${{ parameters.spec | dump }}
+    name: Create a Jenkins
+  type: kratix-resource
+```
+
 ## The Kratix Catalog Entities
 
 The front-end plugin provides specific entity pages for both Kratix Promises and Kratix
@@ -298,7 +346,7 @@ metadata:
     kratix.io/api-group: marketplace.kratix.io # The Group of the resource provided by the Promise
     kratix.io/status: |
       {"message": "Some Status Message"}
-    kratix.io/backstage-promise-template: "create-jenkins" # Name of the Scaffolder template used to create the resource
+    kratix.io/backstage-promise-template: jenkins-promise-template # metadata.name of the Backstage Template used to create the resource
 spec:
   # highlight-next-line
   type: kratix-promise
@@ -336,7 +384,7 @@ metadata:
     kratix.io/kind: Jenkins # Promise API Kind
     kratix.io/name: my-jenkins # Name of the Resource
     kratix.io/namespace: default # Namespace of the Resource
-    kratix.io/backstage-promise-template: "create-jenkins" # Name of the Scaffolder template used to create the resource
+    kratix.io/backstage-promise-template: jenkins-promise-template # metadata.name of the Backstage Template used to create the resource
   #highlight-end
 spec:
   #highlight-start


### PR DESCRIPTION
Updates the SKE docs to include instructions for writing Promise and Resource Components with all of the new annotations and metadata.

fixes syntasso/backstage#10