### PR TITLE
feat: reintroduce vault to the marketplace

### DIFF
--- a/src/data/pipeline-image-data.json
+++ b/src/data/pipeline-image-data.json
@@ -34,5 +34,14 @@
     "categories": [
       "Security"
     ]
+  },
+  {
+    "name": "Vault",
+    "description": "Remove Secret documents and store the values in Vault",
+    "url": "https://github.com/syntasso/kratix-marketplace/tree/main/pipeline-marketplace-images/vault",
+    "logoUrl": "/img/marketplace/images/vault.svg",
+    "categories": [
+      "Security"
+    ]
   }
 ]


### PR DESCRIPTION
This reverts commit 63a012a4c0280dcf6edcb30774253a1176d03e9f.

To be merged after https://github.com/syntasso/kratix-marketplace/pull/7
