### PR TITLE
Document how to use custom certifcates instead of cert-manager

### DIFF
--- a/docs/_partials/installation/_install-cert-manager.md
+++ b/docs/_partials/installation/_install-cert-manager.md
@@ -1,6 +1,79 @@
-Kratix requires [cert-manager](https://cert-manager.io/) to be installed in the
-Platform cluster. If you already have it installed, skip to the
-next section.
+Kratix requires a set of certificates in order to deploy its internal
+[Validating and Mutating Kubernetes
+webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
+By default Kratix is configured to use [cert-manager](https://cert-manager.io/) to
+generate the certificates, therefore we need to install cert-manager. If you already
+have it installed, skip to the next section.
+
+<details>
+
+   <summary> Don't want to use cert-manager? Manually provide the required
+   certificates </summary>
+
+Cert-manager is used to generate a CA, and a key/cert pair which is
+configured for the following DNS names:
+- `kratix-platform-webhook-service.kratix-platform-system.svc.cluster.local`
+- `kratix-platform-webhook-service.kratix-platform-system.svc`
+
+To manually provide the required certificates, you need to create the
+`webhook-server-cert` secret in the `kratix-platform-system` namespace with the
+following keys:
+
+```yaml
+apiVersion: v1
+data:
+  ca.crt: # Base64 encoded Root CA certificate
+  tls.crt: # Base64 encoded Server certificate
+  tls.key: # Base64 encoded Server private key
+kind: Secret
+metadata:
+  name: webhook-server-cert
+  namespace: kratix-platform-system
+type: kubernetes.io/tls
+```
+
+In addition to this, you need to update all occurrences of the `caBundle` field in the following
+resources to contain the base64 encoded root CA certificate:
+- `MutatingWebhookConfiguration/kratix-platform-mutating-webhook-configuration`
+  ```
+  apiVersion: admissionregistration.k8s.io/v1
+  kind: MutatingWebhookConfiguration
+  metadata:
+    name: kratix-platform-mutating-webhook-configuration
+  webhooks:
+  - admissionReviewVersions:
+    - v1
+    clientConfig:
+      caBundle: ....
+  ```
+- `ValidatingWebhookConfiguration/kratix-platform-validating-webhook-configuration`
+  ```
+  apiVersion: admissionregistration.k8s.io/v1
+  kind: ValidatingWebhookConfiguration
+  metadata:
+    name: kratix-platform-validating-webhook-configuration
+  webhooks:
+  - admissionReviewVersions:
+    - v1
+    clientConfig:
+      caBundle: ....
+  ```
+- `CustomResourceDefinition/promises.platform.kratix.io`
+  ```
+  apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    name: promises.platform.kratix.io
+  spec:
+    conversion:
+      strategy: Webhook
+      webhook:
+        clientConfig:
+          caBundle: ....
+  ```
+
+
+</details>
 
 To install it, run:
 

--- a/docs/_partials/installation/_install-cert-manager.md
+++ b/docs/_partials/installation/_install-cert-manager.md
@@ -22,7 +22,7 @@ following keys:
 ```yaml
 apiVersion: v1
 data:
-  ca.crt: # Base64 encoded Root CA certificate
+  ca.crt: # Base64 CA certificate
   tls.crt: # Base64 encoded Server certificate
   tls.key: # Base64 encoded Server private key
 kind: Secret
@@ -32,8 +32,12 @@ metadata:
 type: kubernetes.io/tls
 ```
 
-In addition to this, you need to update all occurrences of the `caBundle` field in the following
-resources to contain the base64 encoded root CA certificate:
+As part of installing Kratix we create a few resources that require the CA
+certificate. You will have to manually add the CA certificate to the resources
+mentioned below, and manually remove the cert-manager `Certificate` and `Issuer`
+resources. The following resources need to be updated to contain the Base64
+encoded CA certificate:
+
 - `MutatingWebhookConfiguration/kratix-platform-mutating-webhook-configuration`
   ```
   apiVersion: admissionregistration.k8s.io/v1
@@ -44,8 +48,9 @@ resources to contain the base64 encoded root CA certificate:
   - admissionReviewVersions:
     - v1
     clientConfig:
-      caBundle: ....
+      caBundle: .... #  there might be multiple admissionReviewVersions, ensure you update all of them
   ```
+
 - `ValidatingWebhookConfiguration/kratix-platform-validating-webhook-configuration`
   ```
   apiVersion: admissionregistration.k8s.io/v1
@@ -56,7 +61,7 @@ resources to contain the base64 encoded root CA certificate:
   - admissionReviewVersions:
     - v1
     clientConfig:
-      caBundle: ....
+      caBundle: .... #  there might be multiple admissionReviewVersions, ensure you update all of them
   ```
 - `CustomResourceDefinition/promises.platform.kratix.io`
   ```
@@ -71,7 +76,6 @@ resources to contain the base64 encoded root CA certificate:
         clientConfig:
           caBundle: ....
   ```
-
 
 </details>
 

--- a/docs/_partials/installation/_install-cert-manager.md
+++ b/docs/_partials/installation/_install-cert-manager.md
@@ -77,6 +77,28 @@ encoded CA certificate:
           caBundle: ....
   ```
 
+Lastly, you need to remove the following cert-manager Issuer and Certificate from Kratix release manifest:
+
+```yaml
+---
+...
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kratix-platform-serving-cert
+  namespace: kratix-platform-system
+spec:
+...
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kratix-platform-selfsigned-issuer
+  namespace: kratix-platform-system
+spec:
+...
+```
+
 </details>
 
 To install it, run:


### PR DESCRIPTION
closes #93 , related to https://github.com/syntasso/kratix/issues/202