### PR TITLE
Remove paved path as marketplace example as out of date

### DIFF
--- a/src/data/promise-data.json
+++ b/src/data/promise-data.json
@@ -203,17 +203,6 @@
 		]
 	},
 	{
-		"name": "Paved Path",
-		"description": "A 'Paved Path' service with Knative and PostgreSQL.       Check the Compound Promises docs for more information.",
-		"url": "https://github.com/syntasso/kratix/tree/main/samples/paved-path-demo/",
-		"logoUrl": "/img/marketplace/pavedpath.svg",
-		"example": true,
-		"categories": [
-			"Example",
-			"Compound Promise"
-		]
-	},
-	{
 		"name": "PostgreSQL",
 		"description": "A SQL-compliant relational database management system",
 		"url": "https://github.com/syntasso/promise-postgresql",


### PR DESCRIPTION
## Description
This promise confuses people as it is based on an older format of Kratix before we had PromiseReleases.

Not deleting the Promise yet as it is referenced in a few other places, but want to get it our of the front page.


## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release? NO
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
