### PR TITLE
chore: add explanation marking CLI as safe on mac

### DIFF
--- a/docs/main/06-kratix-cli/20-reference/07_kratix-init-helm-promise.md
+++ b/docs/main/06-kratix-cli/20-reference/07_kratix-init-helm-promise.md
@@ -12,13 +12,13 @@ kratix init helm-promise PROMISE-NAME --chart-url HELM-CHART-URL --group PROMISE
 ## Examples
 ```
 # initialize a new promise from an OCI Helm Chart
-kratix init helm-promise postgresql --chart-url oci://registry-1.docker.io/bitnamicharts/postgresql [--chart-version]
+kratix init helm-promise postgresql --chart-url oci://registry-1.docker.io/bitnamicharts/postgresql [--group] [--kind] [--chart-version]
 
 # initialize a new promise from a Helm Chart repository
-kratix init helm-promise postgresql --chart-url https://fluxcd-community.github.io/helm-charts --chart-name flux2 [--chart-version]
+kratix init helm-promise flux2 --chart-url https://fluxcd-community.github.io/helm-charts --chart-name flux2  [--group] [--kind] [--chart-version]
 
 # initialize a new promise from a Helm Chart tar URL
-kratix init helm-promise postgresql --chart-url https://github.com/stefanprodan/podinfo/raw/gh-pages/podinfo-0.2.1.tgz
+kratix init helm-promise podinfo --chart-url https://github.com/stefanprodan/podinfo/raw/gh-pages/podinfo-0.2.1.tgz [--group] [--kind]
 ```
 
 ## Flags

--- a/docs/ske/50-releases/40-ske-cli.mdx
+++ b/docs/ske/50-releases/40-ske-cli.mdx
@@ -15,6 +15,16 @@ The releases are available at:
 http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-cli/
 ```
 
+:::info
+
+If you are downloading directly you may need to add the binary to a safe list on your
+computer.
+
+If you are using a mac, you can follow
+[these instructions](https://support.apple.com/en-gb/guide/mac-help/mchleab3a043/mac).
+
+:::
+
 Check the release notes below for information on each available version.
 
 ## Release notes


### PR DESCRIPTION
## Description
This has come up in the community slack and may be nice to have the information more readily accessible for people.

Implemented as a new "info" box and looks like this:
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/dd31b889-2e10-4659-865c-2be0db7330c5">
