### PR TITLE
fix: remove references to imageRegistry.tag as this has been deprecated

### DIFF
--- a/docs/ske/01-kratix/11-helm-installation.mdx
+++ b/docs/ske/01-kratix/11-helm-installation.mdx
@@ -71,7 +71,6 @@ imageRegistry:
   imagePullSecret: "my-secret"
   skeOperatorImage:
     name: "syntasso/ske-operator"
-    tag: "v0.1.5"
   skePlatformImage:
     name: "syntasso/ske-platform"
   skePlatformPipelineAdapterImage:
@@ -140,7 +139,6 @@ Release Storage.
       imagePullSecret: "my-secret"
       skeOperatorImage:
         name: "syntasso/ske-operator"
-        tag: "v0.1.5"
       skePlatformImage:
         name: "syntasso/ske-platform"
       skePlatformPipelineAdapterImage:

--- a/docs/ske/50-releases/20-ske-operator.mdx
+++ b/docs/ske/50-releases/20-ske-operator.mdx
@@ -26,11 +26,19 @@ SKE-Operator, please refer to the release notes below.
 
 ## Release Notes
 
+### [0.4.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator/v0.4.0/) (2024-10-17)
+
+Released in Helm Chart [version 0.16.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator-helm-chart/0.19.0/)
+
+#### Bug Fixes
+
+* Fix bug that made the Operator version configurable as this resulted in errors during upgrades
+
 ### [0.3.1](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator/v0.3.1/) (2024-10-15)
 
 Released in Helm Chart [version 0.16.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator-helm-chart/0.17.0/)
 
-### Bug Fixes
+#### Bug Fixes
 
 * Fix bug preventing Kratix resources from being updated gracefully
 
@@ -38,11 +46,11 @@ Released in Helm Chart [version 0.16.0](http://syntasso-enterprise-releases.s3-w
 
 Released in Helm Chart [version 0.16.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator-helm-chart/0.16.0/)
 
-### Features
+#### Features
 
 * Support pulling releases from a Git Repo for air-gapped environments
 
 
-### Bug Fixes
+#### Bug Fixes
 
 * Fix bug preventing correct version of SKE being returned from the Operator

--- a/docs/ske/50-releases/20-ske-operator.mdx
+++ b/docs/ske/50-releases/20-ske-operator.mdx
@@ -28,7 +28,7 @@ SKE-Operator, please refer to the release notes below.
 
 ### [0.4.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator/v0.4.0/) (2024-10-17)
 
-Released in Helm Chart [version 0.16.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator-helm-chart/0.19.0/)
+Released in Helm Chart [version 0.19.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator-helm-chart/0.19.0/)
 
 #### Bug Fixes
 


### PR DESCRIPTION
## Description
This relates to issue https://github.com/syntasso/enterprise-kratix/issues/150


## Checklist

* [X] Is this PR about a feature in an upcoming SKE release? - SKE Operator helm chart
* [x] Have you cut that new SKE release?
* [x] Have you updated the release notes?
