### PR TITLE
chore: make it clearer that air-gapped has to be helm install for now

### DIFF
--- a/docs/ske/01-kratix/01-air-gapped.mdx
+++ b/docs/ske/01-kratix/01-air-gapped.mdx
@@ -1,6 +1,7 @@
 ---
 title: Setup for Air-Gapped Environments
 description: Installing and running Syntasso Kratix Enterprise in air-gapped environments
+pagination_next: ske/kratix/helm-installation
 ---
 
 ```mdx-code-block

--- a/docs/ske/01-kratix/10-ske-cli-installation.mdx
+++ b/docs/ske/01-kratix/10-ske-cli-installation.mdx
@@ -6,6 +6,14 @@ description: Installing Syntasso Kratix Enterprise
 Syntasso Kratix Enterprise images are distributed through a private image registry. To
 install SKE on your Kubernetes cluster, follow the steps below.
 
+## Air-gapped installations
+
+Support for installing SKE in air-gapped environments using the SKE CLI is coming
+soon.
+
+In the meantime, you can follow the [setup for air-gapped environments](./air-gapped) instructions and
+[install using helm](./helm-installation).
+
 ## Install
 
 :::info
@@ -61,11 +69,3 @@ installing promises). For that, refer to the Open-Source Kratix documentation.
 
 Support for upgrading SKE using the SKE CLI is coming soon. In the meantime, you can
 follow the [helm upgrade](./helm-installation) instructions for upgrading SKE.
-
-## Air-gapped installations
-
-Support for installing SKE in air-gapped environments using the SKE CLI is coming
-soon.
-
-In the meantime, you can follow the [setup for air-gapped environments](./air-gapped) instructions and
-[install using helm](./helm-installation).


### PR DESCRIPTION
This was based on our discussion earlier today in huddle.

The changes are depicted here:
![image](https://github.com/user-attachments/assets/82095cd4-d37f-42c5-b96a-b99c7adefabe)
![image](https://github.com/user-attachments/assets/a6bf8000-e0ad-4084-bddc-6b6d07951201)
