### PR TITLE
fix: should be resourceNames

### DIFF
--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -154,7 +154,7 @@ spec:
               - apiGroups: ["batch"]
                 verbs: ["get"]
                 resources: ["jobs"]
-                resourceName: ["my-job"]
+                resourceNames: ["my-job"]
         ...
 ```
 


### PR DESCRIPTION
## Description

Found out the typo as part of https://github.com/syntasso/kratix/pull/363

Should be resouceNames, see k8s api reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#policyrule-v1-rbac-authorization-k8s-io


## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
