### PR TITLE
docs: add manual reconciliation for delete workflow sections

### DIFF
--- a/docs/main/03-reference/11-promises/06-workflows.md
+++ b/docs/main/03-reference/11-promises/06-workflows.md
@@ -199,17 +199,16 @@ workflow.
 
 ### Manual Reconciliation
 
-After a Promise has been marked for deletion, you may wish to manually trigger the Delete
-workflow (e.g. to re-run the workflow after a pipeline failure).
-
-A Promise can be manually triggered for reconciliation by labelling it as follows:
+After a Promise has been marked for deletion, you can manually trigger the
+Delete workflow (e.g. to re-run the workflow after a pipeline failure) by
+labelling the Promise as follows:
 
 ```yaml
 kratix.io/manual-reconciliation: "true"
 ```
 
-This will trigger the Promise Delete workflow to re-run immediately, terminating any
-Promise Delete workflow that is currently running.
+This will re-run the Promise Delete workflow immediately, terminating any
+workflow that may be in progress.
 
 Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
 it again for any additional manual runs.

--- a/docs/main/03-reference/11-promises/06-workflows.md
+++ b/docs/main/03-reference/11-promises/06-workflows.md
@@ -199,7 +199,8 @@ workflow.
 
 ### Manual Reconciliation
 
-Sometimes (e.g. after a pipeline failure) you may wish to manually trigger a Delete workflow for a specific Promise.
+After a Promise has been marked for deletion, you may wish to manually trigger the Delete
+workflow (e.g. to re-run the workflow after a pipeline failure).
 
 A Promise can be manually triggered for reconciliation by labelling it as follows:
 
@@ -207,9 +208,8 @@ A Promise can be manually triggered for reconciliation by labelling it as follow
 kratix.io/manual-reconciliation: "true"
 ```
 
-This will trigger the Promise Delete workflow to re-run.
-
-This workflow instance will terminate any in-progress Promise Delete workflow and start again.
+This will trigger the Promise Delete workflow to re-run immediately, terminating any
+Promise Delete workflow that is currently running.
 
 Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
 it again for any additional manual runs.

--- a/docs/main/03-reference/11-promises/06-workflows.md
+++ b/docs/main/03-reference/11-promises/06-workflows.md
@@ -197,23 +197,25 @@ itself** (including any retry attempts).
 Kratix will not automatically reschedule/retry any Pipelines which have failed as part of a Delete
 workflow.
 
-### Manual Re-run
+### Manual Reconciliation
 
-After a pipeline failure, you may wish to manually trigger a Delete workflow for a specific Promise.
+Sometimes (e.g. after a pipeline failure) you may wish to manually trigger a Delete workflow for a specific Promise.
 
-A Delete workflow can be manually triggered for reconciliation by labelling it as follows:
+A Promise can be manually triggered for reconciliation by labelling it as follows:
 
 ```yaml
-kratix.io/manual-rerun-delete: "true"
+kratix.io/manual-reconciliation: "true"
 ```
 
 This will trigger the Promise Delete workflow to re-run.
 
+This workflow instance will terminate any in-progress Promise Delete workflow and start again.
+
 Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
 it again for any additional manual runs.
 
-See below for an example command to trigger a manual Delete workflow for a `redis` Promise.
+See below for an example command to trigger a manual reconciliation of a `redis` Promise.
 
 ```
-kubectl label promises.platform.kratix.io redis kratix.io/manual-rerun-delete=true
+kubectl label promises.platform.kratix.io redis kratix.io/manual-reconciliation=true
 ```

--- a/docs/main/03-reference/11-promises/06-workflows.md
+++ b/docs/main/03-reference/11-promises/06-workflows.md
@@ -194,5 +194,26 @@ Kratix will trigger the Delete Pipeline exactly once.
 If a command fails during container execution, this must be handled **within the container
 itself** (including any retry attempts).
 
-Kratix will not reschedule/retry any Pipelines which have failed as part of a Delete
+Kratix will not automatically reschedule/retry any Pipelines which have failed as part of a Delete
 workflow.
+
+### Manual Re-run
+
+After a pipeline failure, you may wish to manually trigger a Delete workflow for a specific Promise.
+
+A Delete workflow can be manually triggered for reconciliation by labelling it as follows:
+
+```yaml
+kratix.io/manual-rerun-delete: "true"
+```
+
+This will trigger the Promise Delete workflow to re-run.
+
+Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
+it again for any additional manual runs.
+
+See below for an example command to trigger a manual Delete workflow for a `redis` Promise.
+
+```
+kubectl label promises.platform.kratix.io redis kratix.io/manual-rerun-delete=true
+```

--- a/docs/main/03-reference/15-resources/02-workflows.md
+++ b/docs/main/03-reference/15-resources/02-workflows.md
@@ -187,8 +187,8 @@ workflow.
 
 ### Manual Reconciliation
 
-Sometimes (e.g. after a pipeline failure) you may wish to manually trigger a Delete workflow for a specific Resource
-Request.
+After a Resource Request has been marked for deletion, you may wish to manually trigger
+the Delete workflow (e.g. to re-run the workflow after a pipeline failure).
 
 A Resource Request can be manually triggered for reconciliation by labelling it as follows:
 
@@ -196,9 +196,8 @@ A Resource Request can be manually triggered for reconciliation by labelling it 
 kratix.io/manual-reconciliation: "true"
 ```
 
-This will trigger the Resource Request Delete workflow to re-run.
-
-This workflow instance will terminate any in-progress Resource Request Delete workflow and start again.
+This will trigger the Resource Delete workflow to re-run immediately, terminating any
+Resource Delete workflow that is currently running.
 
 Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
 it again for any additional manual runs.

--- a/docs/main/03-reference/15-resources/02-workflows.md
+++ b/docs/main/03-reference/15-resources/02-workflows.md
@@ -185,24 +185,26 @@ itself** (including any retry attempts).
 Kratix will not automatically reschedule/retry any Pipelines which have failed as part of a Delete
 workflow.
 
-### Manual Re-run
+### Manual Reconciliation
 
-After a pipeline failure, you may wish to manually trigger a Delete workflow for a specific Resource
+Sometimes (e.g. after a pipeline failure) you may wish to manually trigger a Delete workflow for a specific Resource
 Request.
 
-A Delete workflow can be manually triggered for reconciliation by labelling it as follows:
+A Resource Request can be manually triggered for reconciliation by labelling it as follows:
 
 ```yaml
-kratix.io/manual-rerun-delete: "true"
+kratix.io/manual-reconciliation: "true"
 ```
 
-This will trigger the Resource Delete workflow to re-run.
+This will trigger the Resource Request Delete workflow to re-run.
+
+This workflow instance will terminate any in-progress Resource Request Delete workflow and start again.
 
 Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
 it again for any additional manual runs.
 
-See below for an example command to trigger a manual Delete workflow for a `redis` Resource.
+See below for an example command to trigger a manual reconciliation of a `redis` Resource.
 
 ```
-kubectl label redis my-redis-example kratix.io/manual-rerun-delete=true
+kubectl label redis my-redis-example kratix.io/manual-reconciliation=true
 ```

--- a/docs/main/03-reference/15-resources/02-workflows.md
+++ b/docs/main/03-reference/15-resources/02-workflows.md
@@ -187,20 +187,19 @@ workflow.
 
 ### Manual Reconciliation
 
-After a Resource Request has been marked for deletion, you may wish to manually trigger
-the Delete workflow (e.g. to re-run the workflow after a pipeline failure).
-
-A Resource Request can be manually triggered for reconciliation by labelling it as follows:
+After a Resource Request has been marked for deletion, you can manually trigger
+the Delete workflow (e.g. to re-run the workflow after a pipeline failure) by
+labelling it as follows:
 
 ```yaml
 kratix.io/manual-reconciliation: "true"
 ```
 
-This will trigger the Resource Delete workflow to re-run immediately, terminating any
-Resource Delete workflow that is currently running.
+The Resource Delete workflow will re-run immediately, terminating any other
+workflow that may be in progress.
 
-Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
-it again for any additional manual runs.
+Once Kratix schedules the manual workflow, the label will be removed, allowing
+you to add it again for any additional manual runs.
 
 See below for an example command to trigger a manual reconciliation of a `redis` Resource.
 

--- a/docs/main/03-reference/15-resources/02-workflows.md
+++ b/docs/main/03-reference/15-resources/02-workflows.md
@@ -182,5 +182,27 @@ Kratix will trigger the Delete Pipeline exactly once.
 If a command fails during container execution, this must be handled **within the container
 itself** (including any retry attempts).
 
-Kratix will not reschedule/retry any Pipelines which have failed as part of a Delete
+Kratix will not automatically reschedule/retry any Pipelines which have failed as part of a Delete
 workflow.
+
+### Manual Re-run
+
+After a pipeline failure, you may wish to manually trigger a Delete workflow for a specific Resource
+Request.
+
+A Delete workflow can be manually triggered for reconciliation by labelling it as follows:
+
+```yaml
+kratix.io/manual-rerun-delete: "true"
+```
+
+This will trigger the Resource Delete workflow to re-run.
+
+Once Kratix schedules the manual workflow, the label will be removed, allowing you to add
+it again for any additional manual runs.
+
+See below for an example command to trigger a manual Delete workflow for a `redis` Resource.
+
+```
+kubectl label redis my-redis-example kratix.io/manual-rerun-delete=true
+```

--- a/docs/main/08-troubleshooting.md
+++ b/docs/main/08-troubleshooting.md
@@ -235,11 +235,16 @@ manually remove the finalizer from the resource by editing the resource and
 removing the finalizer from the `.metadata.finalizers`. Kratix will then
 continue to delete and work its way through the remaining finalizers.
 
-1. If the `kratix.io/delete-workflows` finalizer is not being removed, check whether the delete Workflow is failing
+1. If the `kratix.io/delete-workflows` finalizer is not being removed, check to
+   see whether the delete Workflow is failing and fix any issues preventing it from
+   completing.
 
    ```
    kubectl get pods --selector kratix.io/resource-name=<resource-request>
    ```
+
+   Once the issue is fixed, you can trigger the delete Workflow to re-run by triggering a
+   [manual reconciliation](./reference/resources/workflows#manual-reconciliation-1).
 
 1. If the `kratix.io/work-cleanup` finalizer is not being removed, check to see
    whether the `Work`/`WorkPlacement` resources are failing to be deleted
@@ -317,6 +322,9 @@ kubectl -n kratix-platform-system logs <pod-name> -c manager | grep "controllers
    ```
    kubectl -n kratix-platform-system get pods --selector kratix.io/promise-name=<promise-name> --selector kratix.io/work-action=delete
    ```
+
+   Once the issue is fixed, you can trigger the delete Workflow to re-run by triggering a
+   [manual reconciliation](./reference/resources/workflows#manual-reconciliation-1).
 
 1. If the `kratix.io/workflows-cleanup` finalizer is not being removed, check to
    see whether the Workflows are failing to be deleted and manually cleanup any that

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,12 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [v0.20.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.20.0/) (2025-03-11)
+
+#### Features
+
+* Introduces a label to manually re-run a [Promise](/main/reference/promises/workflows#manual-re-run) or [Resource](/main/reference/resources/workflows#manual-re-run) Delete workflow.
+
 ### [v0.19.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.19.0/) (2025-03-04)
 
 #### Features

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -21,9 +21,14 @@ Check the release notes below for information on each available version.
 
 ### [v0.20.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.20.0/) (2025-03-11)
 
+
 #### Features
 
 * Support manual reconciliation of a [Promise](/main/reference/promises/workflows#manual-reconciliation-1) or [Resource](/main/reference/resources/workflows#manual-reconciliation-1) Delete workflow.
+
+#### Security Fixes
+
+* Updated to include latest security updates
 
 ### [v0.19.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.19.0/) (2025-03-04)
 

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -23,7 +23,7 @@ Check the release notes below for information on each available version.
 
 #### Features
 
-* Introduces a label to manually re-run a [Promise](/main/reference/promises/workflows#manual-re-run) or [Resource](/main/reference/resources/workflows#manual-re-run) Delete workflow.
+* Support manual reconciliation of a [Promise](/main/reference/promises/workflows#manual-reconciliation-1) or [Resource](/main/reference/resources/workflows#manual-reconciliation-1) Delete workflow.
 
 ### [v0.19.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.19.0/) (2025-03-04)
 


### PR DESCRIPTION
## Description
This relates to issue [#383](https://github.com/syntasso/kratix/issues/383).

Added sections for both Promise and Resource Delete workflows. 

## Checklist

* [x] Is this PR about a feature in an upcoming SKE release?
* [x] Have you cut that new SKE release?
* [x] Have you updated the release notes?
