### PR TITLE
docs: add release notes and docs for v0.19.0

### DIFF
--- a/docs/main/03-reference/13-destinations/01-destinations.md
+++ b/docs/main/03-reference/13-destinations/01-destinations.md
@@ -143,3 +143,31 @@ often required by GitOps tools to ensure that all dependencies are ready before 
 resources themselves are applied.
 
 :::
+
+## Status
+
+A condition of type `Ready` is provided to enable waiting for the Destination to be ready. The Destination is considered
+ready when Kratix is able to write test documents successfully.
+
+See the example below showing a Destination with `Ready` condition.
+
+```
+$ kubectl describe destinations.platform.kratix.io worker-1
+Name:         worker-1
+...
+Status:
+  Conditions:
+    Last Transition Time:  2025-03-04T15:26:21Z
+    Message:               Test documents written to State Store
+    Reason:                TestDocumentsWritten
+    Status:                True
+    Type:                  Ready
+```
+
+:::info
+
+The test documents include `dependencies/kratix-canary-namespace.yaml` and `resources/kratix-canary-configmap.yaml`. When
+the `Ready` condition status is `True` and the target is a Kubernetes cluster set up to reconcile on the Destination, you
+will see a `kratix-worker-system` namespace and a `kratix-info` configmap on the target cluster.
+
+:::

--- a/docs/main/03-reference/14-statestore/02-gitstatestore.md
+++ b/docs/main/03-reference/14-statestore/02-gitstatestore.md
@@ -113,3 +113,37 @@ field with the values generated for the HTTPS Git credentials.
 Require a different method of authentication? Get in touch with us at
 [feedback@syntasso.io](mailto:feedback@syntasso.io?subject=Kratix%20Feedback)
 or [open a GitHub Issue](https://github.com/syntasso/kratix/issues/new).
+
+## Status
+
+The status of the GitStateStore can be `Ready` or `NotReady` based on Kratix's availability to write to the State Store.
+
+A condition of type `Ready` is also provided to enable waiting for the State Store to be ready.
+
+An example is provided below showing a GitStateStore coming online, including events detailing any status changes.
+
+```
+$ kubectl describe gitstatestores.platform.kratix.io default
+Name:         default
+...
+Status:
+  Conditions:
+    Last Transition Time:  2025-03-05T12:53:12Z
+    Message:               State store is ready
+    Reason:                StateStoreReady
+    Status:                True
+    Type:                  Ready
+  Status:                  Ready
+Events:
+  Type     Reason    Age    From                     Message
+  ----     ------    ----   ----                     -------
+  Warning  NotReady  2m44s  GitStateStoreController  GitStateStore "default" is not ready: Error writing test file: Get "https://172.18.0.2:31333/gitea_admin/kratix/info/refs?service=git-upload-pack": dial tcp 172.18.0.2:31333: connect: connection refused
+  Warning  NotReady  2m32s  GitStateStoreController  GitStateStore "default" is not ready: Error writing test file: repository not found: Repository not found
+  Normal   Ready     2m21s  GitStateStoreController  GitStateStore "default" is ready
+```
+
+:::info
+
+Kratix determines whether it can write to the State Store by writing a `kratix-write-probe.txt` file under the State Store's `.spec.path` filepath.
+
+:::

--- a/docs/main/03-reference/14-statestore/03-bucketstatestore.md
+++ b/docs/main/03-reference/14-statestore/03-bucketstatestore.md
@@ -118,3 +118,35 @@ endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.h
 Require a different method of authentication? Get in touch with us at
 [feedback@syntasso.io](mailto:feedback@syntasso.io?subject=Kratix%20Feedback)
 or [open a GitHub Issue](https://github.com/syntasso/kratix/issues/new).
+
+## Status
+
+The status of the BucketStateStore can be `Ready` or `NotReady` based on Kratix's availability to write to the State Store.
+
+A condition of type `Ready` is also provided to enable waiting for the State Store to be ready.
+
+An example is provided below showing a BucketStateStore coming online, including events detailing any status changes.
+
+```
+$ kubectl describe bucketstatestores.platform.kratix.io default
+Name:         default
+...
+Status:
+  Conditions:
+    Last Transition Time:  2025-03-05T12:52:49Z
+    Message:               State store is ready
+    Reason:                StateStoreReady
+    Status:                True
+    Type:                  Ready
+  Status:                  Ready
+Events:
+  Type    Reason  Age   From                        Message
+  ----    ------  ----  ----                        -------
+  Normal  Ready   11m   BucketStateStoreController  BucketStateStore "default" is ready
+```
+
+:::info
+
+Kratix determines whether it can write to the State Store by writing a `kratix-write-probe.txt` file under the State Store's `.spec.path` filepath.
+
+:::

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,17 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [v0.19.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.19.0/) (2025-03-04)
+
+#### Features
+
+* Introduced a `Ready` status and condition, and events, for [GitStateStores](/main/reference/statestore/gitstatestore#status) and [BucketStateStores](/main/reference/statestore/bucketstatestore#status).
+* Introduced a `Ready` condition for [Destinations](/main/reference/destinations/intro#status).
+
+#### Bug fixes
+
+* Upgraded SKE core dependencies to fix [Golang CVE](https://pkg.go.dev/vuln/GO-2025-3487) from previous release.
+
 ### [v0.18.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.18.0/) (2025-02-26)
 
 #### Features


### PR DESCRIPTION
## Description
This contains the release notes for v0.19.0 and status sections for Destinations, GitStateStores, and BucketStateStores.


## Checklist

* [x] Is this PR about a feature in an upcoming SKE release?
* [x] Have you cut that new SKE release?
* [x] Have you updated the release notes?
