### PR TITLE
chore: make block highlight more obvious

### DIFF
--- a/docs/workshop/part-ii/03-secrets-and-state.mdx
+++ b/docs/workshop/part-ii/03-secrets-and-state.mdx
@@ -45,7 +45,7 @@ stringData:
 EOF
 ```
 
-Next update your Promise with the new `create-bucket` step. From within this step, you will load the secret defined above as an environment variable:
+Next edit your Promise with the new `create-bucket` step. From within this step, you will load the secret defined above as an environment variable. Please copy only the highlighted block to your existing Promise definition:
 
 ```yaml title="app-promise/promise.yaml"
 apiVersion: platform.kratix.io/v1alpha1
@@ -53,9 +53,9 @@ kind: Promise
 metadata:
   name: app
 spec:
-  api: #...
+  api: #... abbreviated
   workflows:
-    promise: #...
+    promise: #... abbreviated
     resource:
       configure:
         - apiVersion: platform.kratix.io/v1alpha1
@@ -191,9 +191,9 @@ kind: Promise
 metadata:
   name: app
 spec:
-  api: #...
+  api: #... abbreviated
   workflows:
-    promise: #...
+    promise: #... abbreviated
     resource:
       configure:
         - apiVersion: platform.kratix.io/v1alpha1

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -14,7 +14,7 @@
   --ifm-color-primary-lighter: #E4DAFF;
   --ifm-color-primary-lightest: #F8F3FF;
   --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --docusaurus-highlighted-code-line-bg: rgba(230, 176, 112, 0.2);
 
 
   --heading-color: #3e4656;
@@ -33,7 +33,7 @@
   --ifm-color-primary-light: #eacdff;
   --ifm-color-primary-lighter: #E4DAFF;
   --ifm-color-primary-lightest: #F8F3FF;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
 
   --heading-color: #fff;
   --color-purple: #d69dff;


### PR DESCRIPTION
## Description
closes #221 

Highlight in light:
<img width="726" alt="Screenshot 2025-04-14 at 06 07 23" src="https://github.com/user-attachments/assets/37a4fa65-1e83-4073-acc2-de97f062bd56" />

Highlight in dark:
<img width="707" alt="Screenshot 2025-04-14 at 06 07 15" src="https://github.com/user-attachments/assets/bd59beee-cefc-4296-ba02-1a9411f57851" />


## Checklist
not related to any feature or release

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
