### PR TITLE
chore: include full promise definition in workshop

### DIFF
--- a/docs/workshop/part-ii/03-secrets-and-state.mdx
+++ b/docs/workshop/part-ii/03-secrets-and-state.mdx
@@ -292,6 +292,23 @@ Awesome! You pipeline stage is now idempotent, so go ahead and apply the promise
 kubectl --context $PLATFORM apply --filename promise.yaml
 ```
 
+<details>
+<summary>
+
+_Click here_ for the full `promise.yaml` file.
+
+</summary>
+
+```mdx-code-block
+import FullPromise from "!!raw-loader!./_partials/secrets-and-state/04-full-promise.yaml"
+```
+
+<CodeBlock language="yaml" title="app-promise/promise.yaml">
+  {FullPromise}
+</CodeBlock>
+
+</details>
+
 As soon as the Promise is applied, Kratix will trigger an update for the existing application. Once the pipeline completes, you should see a new Bucket on your MinIO server:
 
 ```bash

--- a/docs/workshop/part-ii/06-compound-promise.mdx
+++ b/docs/workshop/part-ii/06-compound-promise.mdx
@@ -357,6 +357,22 @@ kubectl --context $PLATFORM apply --filename promise.yaml
 
 Great! Your App-as-a-Service Promise is now a Compound Promise that can request a PostgreSQL service. You can now test it by making a request for an App-as-a-Service with a PostgreSQL service.
 
+<details>
+<summary>
+
+_Click here_ for the full `promise.yaml` file.
+
+</summary>
+
+```mdx-code-block
+import FullPromise from "!!raw-loader!./_partials/compound-promise/01-full-promise.yaml"
+```
+
+<CodeBlock language="yaml" title="app-promise/promise.yaml">
+  {FullPromise}
+</CodeBlock>
+
+</details>
 
 :::warning
 

--- a/docs/workshop/part-ii/_partials/compound-promise/01-full-promise.yaml
+++ b/docs/workshop/part-ii/_partials/compound-promise/01-full-promise.yaml
@@ -1,0 +1,105 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  creationTimestamp: null
+  labels:
+    kratix.io/promise-version: v0.0.1
+  name: app
+spec:
+  requiredPromises:
+    - name: postgresql
+      version: v1.0.0-beta.2
+  api:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      creationTimestamp: null
+      name: apps.workshop.kratix.io
+    spec:
+      group: workshop.kratix.io
+      names:
+        kind: App
+        plural: apps
+        singular: app
+      scope: Namespaced
+      versions:
+        - name: v1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  properties:
+                    dbDriver:
+                      type: string
+                    image:
+                      type: string
+                    service:
+                      properties:
+                        port:
+                          type: integer
+                      type: object
+                  type: object
+              type: object
+          served: true
+          storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: null
+      storedVersions: null
+  workflows:
+    promise:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: dependencies
+          spec:
+            containers:
+              - image: kratix-workshop/app-promise-pipeline:v0.1.0
+                name: configure-deps
+    resource:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: mypipeline
+          spec:
+            containers:
+              - command:
+                  - resource-configure
+                image: kratix-workshop/app-pipeline-image:v1.0.0
+                name: kratix-workshop-app-pipeline-image
+              - command:
+                  - create-bucket
+                env:
+                  - name: MINIO_ENDPOINT
+                    valueFrom:
+                      secretKeyRef:
+                        key: endpoint
+                        name: app-promise-minio-creds
+                  - name: MINIO_USER
+                    valueFrom:
+                      secretKeyRef:
+                        key: username
+                        name: app-promise-minio-creds
+                  - name: MINIO_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        key: password
+                        name: app-promise-minio-creds
+                image: kratix-workshop/app-pipeline-image:v1.0.0
+                name: create-bucket
+              - name: database-configure
+                image: kratix-workshop/app-pipeline-image:v1.0.0
+                command: [ database-configure ]
+            rbac:
+              permissions:
+                - apiGroups:
+                    - ""
+                  resources:
+                    - configmaps
+                  verbs:
+                    - '*'
+status: {}

--- a/docs/workshop/part-ii/_partials/secrets-and-state/04-full-promise.yaml
+++ b/docs/workshop/part-ii/_partials/secrets-and-state/04-full-promise.yaml
@@ -1,0 +1,92 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  creationTimestamp: null
+  labels:
+    kratix.io/promise-version: v0.0.1
+  name: app
+spec:
+  api:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      creationTimestamp: null
+      name: apps.workshop.kratix.io
+    spec:
+      group: workshop.kratix.io
+      names:
+        kind: App
+        plural: apps
+        singular: app
+      scope: Namespaced
+      versions:
+        - name: v1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  properties:
+                    image:
+                      type: string
+                    service:
+                      properties:
+                        port:
+                          type: integer
+                      type: object
+                  type: object
+              type: object
+          served: true
+          storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: null
+      storedVersions: null
+  workflows:
+    promise:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: dependencies
+          spec:
+            containers:
+              - image: kratix-workshop/app-promise-pipeline:v0.1.0
+                name: configure-deps
+    resource:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: mypipeline
+          spec:
+            rbac:
+              permissions:
+                - apiGroups: [ "" ]
+                  verbs: [ "*" ]
+                  resources: [ "configmaps" ]
+            containers:
+              - image: kratix-workshop/app-pipeline-image:v1.0.0
+                name: kratix-workshop-app-pipeline-image
+                command: [ resource-configure ]
+              - name: create-bucket
+                image: kratix-workshop/app-pipeline-image:v1.0.0
+                command: [ create-bucket ]
+                env:
+                  - name: MINIO_ENDPOINT
+                    valueFrom:
+                      secretKeyRef:
+                        name: app-promise-minio-creds
+                        key: endpoint
+                  - name: MINIO_USER
+                    valueFrom:
+                      secretKeyRef:
+                        name: app-promise-minio-creds
+                        key: username
+                  - name: MINIO_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: app-promise-minio-creds
+                        key: password
+status: {}


### PR DESCRIPTION
## Description
closes #205 

- so people can have a reference point if they would like to double check the promise.yaml; added to section c and e because they actively edit the promise.yaml
- 
## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
