### PR TITLE
chore: update app-as-a-service to marketplace URL

### DIFF
--- a/src/data/promise-data.json
+++ b/src/data/promise-data.json
@@ -27,7 +27,7 @@
 	{
 		"name": "App-as-a-Service",
 		"description": "An example Promise delivering 'App-as-a-Service'.       Check the Compound Promises docs for more information.",
-		"url": "https://github.com/syntasso/kratix/tree/main/demo/app-as-a-service",
+		"url": "https://github.com/syntasso/kratix-marketplace/tree/main/app-as-a-service",
 		"logoUrl": "/img/marketplace/app-as-a-service.svg",
 		"example": true,
 		"categories": [


### PR DESCRIPTION
Point marketplace to the better support app-as-a-service example in the correct repo.