### PR TITLE
feat: expose more envvars for pipeline containers

### DIFF
--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -387,6 +387,13 @@ workflow:
 | `KRATIX_WORKFLOW_TYPE`    | The type of workflow. Either `resource` or `promise`. |
 | `KRATIX_PROMISE_NAME`     | The name of the Promise. |
 | `KRATIX_PIPELINE_NAME`    | The name of the Pipeline. |
+| `KRATIX_OBJECT_KIND`      | The kind of the object in `/kratix/input/object.yaml`. |
+| `KRATIX_OBJECT_GROUP`     | The group of the object in `/kratix/input/object.yaml`. |
+| `KRATIX_OBJECT_VERSION`   | The version of the object in `/kratix/input/object.yaml`. |
+| `KRATIX_OBJECT_NAME`      | The name of the object in `/kratix/input/object.yaml`. |
+| `KRATIX_OBJECT_NAMESPACE` | The namespace of the object in `/kratix/input/object.yaml`. |
+| `KRATIX_CRD_PLURAL`       | The plural for the API defined in the Promise. |
+| `KRATIX_CLUSTER_SCOPED`   | A boolean for if the Promise API is cluster scoped. |
 
 By checking the `KRATIX_WORKFLOW_ACTION` and `KRATIX_WORKFLOW_TYPE` environment variables,
 a container is able to discover the **context** in which it's being invoked (e.g. "I'm


### PR DESCRIPTION
Standardise KRATIX_ prefix for envvars and expose the object name in the pipeline images by default. This allows people to do more useful inline containers as they can use vars that are unique.

## Description
Docs for https://github.com/syntasso/kratix/pull/456
