### PR TITLE
docs: misscheduled -> misplaced

### DIFF
--- a/docs/main/03-reference/11-promises/03-updates.md
+++ b/docs/main/03-reference/11-promises/03-updates.md
@@ -40,16 +40,16 @@ The scheduling for a Promise may be changed by modifying either:
 See [Managing Multiple Destinations](../destinations/multidestination-management) for more
 details on scheduling.
 
-### Misscheduled workloads
+### Misplaced workloads
 
 An update to the Promise's scheduling may result in a set of Destinations previously
 targeted from old version of the Promise no longer being targeted.
 
 When this happens, existing files written to the Destination **are not removed**, but are
-marked as `misscheduled` by Kratix and are **not updated any more**.
+marked as `misplaced` by Kratix and are **not updated any more**.
 
 It's up to the platform team to manually delete these resources by deleting all
-`WorkPlacement` resources marked with the `kratix.io/misscheduled` label.
+`WorkPlacement` resources marked with the `kratix.io/misplaced` label.
 
 #### Example
 


### PR DESCRIPTION
- will be released in the next SKE

## Description
This relates to issue #
Related to PR of kratix https://github.com/syntasso/kratix/pull/484
Will be released in the next SKE

## Checklist

* [X] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release? no
* [ ] Have you updated the release notes? no
