### PR TITLE
Add docs for backoffLimit

### DIFF
--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -93,10 +93,22 @@ for more information on the fields above.
 
 :::note
 
+
 Not all fields from the Pod spec are supported. We will add support for more fields in
 the future.
 
 :::
+
+### Job Lifecycle
+
+Kratix runs each Pipeline as a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/).
+You can control how many completed Jobs are kept and how many times a failing Job
+is retried via the [`kratix` ConfigMap](/main/reference/kratix-config/config):
+
+* `numberOfJobsToKeep` sets the maximum number of successful pipeline Jobs to retain.
+* `backoffLimit` determines how many times Kubernetes retries a failing Job before
+  marking it failed. Kratix does not set a default value for this field; if omitted,
+  Kubernetes uses its own Job default.
 
 ### RBAC
 
@@ -451,6 +463,9 @@ containers (not Kratix containers) by either:
     namespace: kratix-platform-system
   data:
     config: |
+      # Number of times Kubernetes retries a failing workflow Job before marking it failed
+      # Kratix does not set a default for this field; Kubernetes uses its own Job default if omitted
+      backoffLimit: 6
       workflows:
         defaultContainerSecurityContext:
           # Security context fields, e.g.:

--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -466,9 +466,6 @@ containers (not Kratix containers) by either:
     namespace: kratix-platform-system
   data:
     config: |
-      # Number of times Kubernetes retries a failing workflow Job before marking it failed
-      # Kratix does not set a default for this field; Kubernetes uses its own Job default if omitted
-      backoffLimit: 6
       workflows:
         defaultContainerSecurityContext:
           # Security context fields, e.g.:

--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -71,6 +71,9 @@ metadata:
   labels: # Labels (optional)
   annotations: # Annotations (optional)
 spec:
+  jobOptions:
+    # Number of times Kubernetes retries a failing workflow Job before marking it failed.
+    backoffLimit: 4
   volumes:
     - # Volume definitions, in addition to `/kratix` volumes (optional)
   containers:

--- a/docs/main/03-reference/17-kratix-config/kratix-config.md
+++ b/docs/main/03-reference/17-kratix-config/kratix-config.md
@@ -27,7 +27,7 @@ data:
     # Number of times Kubernetes retries a failing workflow Job before marking it failed.
     # Kratix does not set a default for this field, so Kubernetes uses its own
     # Job default (6) if it is omitted.
-    backoffLimit: 6
+    backoffLimit: 4
     # Selective cache for Secrets to limit memory usage. Please ensure Secrets used by Kratix are
     # created with label: app.kubernetes.io/part-of=kratix. Default is false.
     selectiveCache: false

--- a/docs/main/03-reference/17-kratix-config/kratix-config.md
+++ b/docs/main/03-reference/17-kratix-config/kratix-config.md
@@ -24,6 +24,10 @@ data:
   config: |
     # Number of old successful pipeline pods to keep. Default is 5
     numberOfJobsToKeep: 1
+    # Number of times Kubernetes retries a failing workflow Job before marking it failed.
+    # Kratix does not set a default for this field, so Kubernetes uses its own
+    # Job default (6) if it is omitted.
+    backoffLimit: 6
     # Selective cache for Secrets to limit memory usage. Please ensure Secrets used by Kratix are
     # created with label: app.kubernetes.io/part-of=kratix. Default is false.
     selectiveCache: false

--- a/docs/main/05-learn-more/02-kratix-resources.mdx
+++ b/docs/main/05-learn-more/02-kratix-resources.mdx
@@ -81,6 +81,7 @@ Apart from the `status-writer`, all containers are actually set as `initContaine
 :::
 
 Kratix creates a new Job every time a new workflow needs to be executed. You can control the number of Jobs that Kratix keeps by setting `numberOfJobsToKeep` in the [Kratix Config](/main/reference/kratix-config/config) document.
+You can also configure how many times a failing workflow Job is retried by setting `backoffLimit` in the same ConfigMap. Kratix does not provide a default value for this field.
 
 ## Output Objects
 


### PR DESCRIPTION
## Summary
- note how to control retry count for workflow Jobs via `backoffLimit`
- mention `backoffLimit` option in Kratix config example
- clarify with a YAML comment in the Workflows doc

## Testing
- `yarn build` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.8.1/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_b_6841a8957de48322975e587fb3c955d7