### PR TITLE
fix: secret creation for healthcheckcs

### DIFF
--- a/docs/ske/01-kratix/10-ske-health-agent.mdx
+++ b/docs/ske/01-kratix/10-ske-health-agent.mdx
@@ -53,7 +53,6 @@ kind: Secret
 metadata:
   name: <secret name>
   namespace: k8s-health-agent-system
-type: kubernetes.io/basic-auth
 stringData:
   # for basicAuth
   username: # username


### PR DESCRIPTION
when that field is set, k8s expect `.data.username` and `.data.password` to be set and errors if its not 
