### PR TITLE
Add docs on status conditions and events

### DIFF
--- a/docs/main/01-quick-start.md
+++ b/docs/main/01-quick-start.md
@@ -21,13 +21,13 @@ other subject matter experts who need to contribute and manage their services wh
 consumers are often application developers, data scientists, managers and others who
 need to depend on and use the provided services.
 
+
 ## Prerequisites
 
 To follow along, you'll need access to a Kubernetes cluster.
 
 We recommend using a clean, disposable cluster for this quick start and you can use any
 Kubernetes distribution including:
-
 - Managed services like GKE, EKS, or AKS
 - On-premises clusters like OpenShift, Rancher, or vanilla Kubernetes
 - Local environments like KinD or Minikube
@@ -38,7 +38,7 @@ quick start deploys a local, insecure MinIO instance—intended only for local d
 
 ## Installation
 
-Kratix extends the Kubernetes API by introducing custom resources and controllers.
+Kratix extends the Kubernetes API by introducing custom resources and controllers. 
 
 :::tip
 While Kratix runs on Kubernetes, it orchestrates resources both in and outside of Kubernetes.
@@ -52,18 +52,18 @@ quick-start that uses a single job to install Kratix with sensible defaults.
 <details>
   <summary>What gets installed?</summary>
 
-The install manifest does the following:
+  The install manifest does the following:
 
-1. Installs [**cert-manager**](https://cert-manager.io/) to manage TLS certificates for
-   Kratix webhooks
-1. Deploys the [**Kratix API server and controllers**](https://docs.kratix.io/main/learn-more/kratix-resources)
-   in the `kratix-system` namespace
-1. Deploys [**MinIO**](https://min.io/), a local S3-compatible bucket for storing
-   declarative workloads
-1. Installs and configures [**Flux**](https://fluxcd.io/) to apply changes from the
-   MinIO bucket via GitOps
-1. Registers your Kubernetes cluster as a [**Destination**](https://docs.kratix.io/main/reference/destinations/intro)
-so Kratix can schedule workloads to it
+  1. Installs [**cert-manager**](https://cert-manager.io/) to manage TLS certificates for
+      Kratix webhooks
+  1. Deploys the [**Kratix API server and controllers**](https://docs.kratix.io/main/learn-more/kratix-resources)
+      in the `kratix-system` namespace
+  1. Deploys [**MinIO**](https://min.io/), a local S3-compatible bucket for storing
+      declarative workloads
+  1. Installs and configures [**Flux**](https://fluxcd.io/) to apply changes from the
+      MinIO bucket via GitOps
+  1. Registers your Kubernetes cluster as a [**Destination**](https://docs.kratix.io/main/reference/destinations/intro)
+      so Kratix can schedule workloads to it
 </details>
 
 Install Kratix:
@@ -236,8 +236,8 @@ Kubernetes resources to create the PostgreSQL instance. Those resources were
 then scheduled to the Platform via the GitOps repo (in this simple scenario, an
 in-cluster s3 compatible bucket using MinIO).
 
-You can see the workflows that were run by inspecting the Pods:
 
+You can see the workflows that were run by inspecting the Pods:
 ```bash
 kubectl get pods -l kratix.io/promise-name=postgresql
 ```
@@ -252,25 +252,14 @@ kubectl get postgresqls.marketplace.kratix.io example -o yaml
 ```
 
 ```yaml
-
----
+...
 status:
   conditions:
-    - lastTransitionTime: "2025-05-27T13:15:15Z"
-      message: Pipelines completed
-      reason: PipelinesExecutedSuccessfully
-      status: "True"
-      type: ConfigureWorkflowCompleted
-    - lastTransitionTime: "2025-05-27T13:15:15Z"
-      message: All works associated with this resource are ready
-      reason: WorksSucceeded
-      status: "True"
-      type: WorksSucceeded
-    - lastTransitionTime: "2025-05-27T13:15:16Z"
-      message: Reconciled
-      reason: Reconciled
-      status: "True"
-      type: Reconciled
+  - lastTransitionTime: "2025-05-27T13:15:15Z"
+    message: Pipelines completed
+    reason: PipelinesExecutedSuccessfully
+    status: "True"
+    type: ConfigureWorkflowCompleted
   connectionDetails:
     credentials: 'Username and Password available in Secret: "default/postgres.acme-org-team-a-example-postgresql.credentials.postgresql.acid.zalan.do"'
     host: acme-org-team-a-example-postgresql.default.svc.cluster.local
@@ -278,6 +267,7 @@ status:
   lastSuccessfulConfigureWorkflowTime: "2025-05-27T13:15:15Z"
   message: 1Gi instance v16 deployed successfully without backups
   observedGeneration: 4
+
 ```
 
 These fields are how the producer communicates important information to the consumer
@@ -291,9 +281,9 @@ focus on building your platform your way.
 ### Update an Instance
 
 Kratix isn't a fire and forget solution; it handles the full lifecycle,
-including all day 2 operations. For example, if your requirements change, it's
-easy to adapt. As a consumer, you simply update the spec and re-submit the
-request. Promises are designed to safely handle updates without requiring
+including all day 2 operations.  For example, if your requirements change, it's
+easy to adapt. As a consumer,  you simply update the spec and re-submit the
+request. Promises are designed  to safely handle updates without requiring
 custom scripts or manual intervention.
 
 For example, introducing backups is as simple as adding another field to the request:
@@ -355,11 +345,9 @@ kubectl apply -f https://raw.githubusercontent.com/syntasso/promise-postgresql/r
 ```
 
 This will create 2 more instances as shown below:
-
 ```bash
 kubectl get pods -l application=spilo
 ```
-
 ```bash
 NAME                                   READY   STATUS    RESTARTS   AGE
 ...

--- a/docs/main/01-quick-start.md
+++ b/docs/main/01-quick-start.md
@@ -21,13 +21,13 @@ other subject matter experts who need to contribute and manage their services wh
 consumers are often application developers, data scientists, managers and others who
 need to depend on and use the provided services.
 
-
 ## Prerequisites
 
 To follow along, you'll need access to a Kubernetes cluster.
 
 We recommend using a clean, disposable cluster for this quick start and you can use any
 Kubernetes distribution including:
+
 - Managed services like GKE, EKS, or AKS
 - On-premises clusters like OpenShift, Rancher, or vanilla Kubernetes
 - Local environments like KinD or Minikube
@@ -38,7 +38,7 @@ quick start deploys a local, insecure MinIO instance—intended only for local d
 
 ## Installation
 
-Kratix extends the Kubernetes API by introducing custom resources and controllers. 
+Kratix extends the Kubernetes API by introducing custom resources and controllers.
 
 :::tip
 While Kratix runs on Kubernetes, it orchestrates resources both in and outside of Kubernetes.
@@ -52,18 +52,18 @@ quick-start that uses a single job to install Kratix with sensible defaults.
 <details>
   <summary>What gets installed?</summary>
 
-  The install manifest does the following:
+The install manifest does the following:
 
-  1. Installs [**cert-manager**](https://cert-manager.io/) to manage TLS certificates for
-      Kratix webhooks
-  1. Deploys the [**Kratix API server and controllers**](https://docs.kratix.io/main/learn-more/kratix-resources)
-      in the `kratix-system` namespace
-  1. Deploys [**MinIO**](https://min.io/), a local S3-compatible bucket for storing
-      declarative workloads
-  1. Installs and configures [**Flux**](https://fluxcd.io/) to apply changes from the
-      MinIO bucket via GitOps
-  1. Registers your Kubernetes cluster as a [**Destination**](https://docs.kratix.io/main/reference/destinations/intro)
-      so Kratix can schedule workloads to it
+1. Installs [**cert-manager**](https://cert-manager.io/) to manage TLS certificates for
+   Kratix webhooks
+1. Deploys the [**Kratix API server and controllers**](https://docs.kratix.io/main/learn-more/kratix-resources)
+   in the `kratix-system` namespace
+1. Deploys [**MinIO**](https://min.io/), a local S3-compatible bucket for storing
+   declarative workloads
+1. Installs and configures [**Flux**](https://fluxcd.io/) to apply changes from the
+   MinIO bucket via GitOps
+1. Registers your Kubernetes cluster as a [**Destination**](https://docs.kratix.io/main/reference/destinations/intro)
+so Kratix can schedule workloads to it
 </details>
 
 Install Kratix:
@@ -236,8 +236,8 @@ Kubernetes resources to create the PostgreSQL instance. Those resources were
 then scheduled to the Platform via the GitOps repo (in this simple scenario, an
 in-cluster s3 compatible bucket using MinIO).
 
-
 You can see the workflows that were run by inspecting the Pods:
+
 ```bash
 kubectl get pods -l kratix.io/promise-name=postgresql
 ```
@@ -252,14 +252,25 @@ kubectl get postgresqls.marketplace.kratix.io example -o yaml
 ```
 
 ```yaml
-...
+
+---
 status:
   conditions:
-  - lastTransitionTime: "2025-05-27T13:15:15Z"
-    message: Pipelines completed
-    reason: PipelinesExecutedSuccessfully
-    status: "True"
-    type: ConfigureWorkflowCompleted
+    - lastTransitionTime: "2025-05-27T13:15:15Z"
+      message: Pipelines completed
+      reason: PipelinesExecutedSuccessfully
+      status: "True"
+      type: ConfigureWorkflowCompleted
+    - lastTransitionTime: "2025-05-27T13:15:15Z"
+      message: All works associated with this resource are ready
+      reason: WorksSucceeded
+      status: "True"
+      type: WorksSucceeded
+    - lastTransitionTime: "2025-05-27T13:15:16Z"
+      message: Reconciled
+      reason: Reconciled
+      status: "True"
+      type: Reconciled
   connectionDetails:
     credentials: 'Username and Password available in Secret: "default/postgres.acme-org-team-a-example-postgresql.credentials.postgresql.acid.zalan.do"'
     host: acme-org-team-a-example-postgresql.default.svc.cluster.local
@@ -267,7 +278,6 @@ status:
   lastSuccessfulConfigureWorkflowTime: "2025-05-27T13:15:15Z"
   message: 1Gi instance v16 deployed successfully without backups
   observedGeneration: 4
-
 ```
 
 These fields are how the producer communicates important information to the consumer
@@ -281,9 +291,9 @@ focus on building your platform your way.
 ### Update an Instance
 
 Kratix isn't a fire and forget solution; it handles the full lifecycle,
-including all day 2 operations.  For example, if your requirements change, it's
-easy to adapt. As a consumer,  you simply update the spec and re-submit the
-request. Promises are designed  to safely handle updates without requiring
+including all day 2 operations. For example, if your requirements change, it's
+easy to adapt. As a consumer, you simply update the spec and re-submit the
+request. Promises are designed to safely handle updates without requiring
 custom scripts or manual intervention.
 
 For example, introducing backups is as simple as adding another field to the request:
@@ -345,9 +355,11 @@ kubectl apply -f https://raw.githubusercontent.com/syntasso/promise-postgresql/r
 ```
 
 This will create 2 more instances as shown below:
+
 ```bash
 kubectl get pods -l application=spilo
 ```
+
 ```bash
 NAME                                   READY   STATUS    RESTARTS   AGE
 ...

--- a/docs/main/03-reference/15-resources/04-status.md
+++ b/docs/main/03-reference/15-resources/04-status.md
@@ -92,21 +92,20 @@ spec:
   workflows:
     resource:
       configure:
-      - apiVersion: platform.kratix.io/v1alpha1
-        kind: Pipeline
-        metadata:
-          name: create-user
-        spec:
-          containers:
-          - image: create-db:v0.1.0
-      - apiVersion: platform.kratix.io/v1alpha1
-        kind: Pipeline
-        metadata:
-          name: populate-vault
-        spec:
-          containers:
-          - image: populate-vault:v0.1.0
-
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: create-user
+          spec:
+            containers:
+              - image: create-db:v0.1.0
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: populate-vault
+          spec:
+            containers:
+              - image: populate-vault:v0.1.0
 ```
 
 And the first pipeline wrote the following to `/kratix/metadata/status.yaml`:
@@ -122,17 +121,15 @@ Then the second pipeline would see the following in the `/kratix/input/object.ya
 ```yaml
 apiVersion: ...
 kind: ...
-metadata:
-  ...
-spec:
-  ...
+metadata: ...
+spec: ...
 status:
   conditions: # this is being automatically set by Kratix
-  - lastTransitionTime: "2024-08-21T10:27:45Z"
-    message: Pipelines are still in progress
-    reason: PipelinesInProgress
-    status: "False"
-    type: ConfigureWorkflowCompleted
+    - lastTransitionTime: "2024-08-21T10:27:45Z"
+      message: Pipelines are still in progress
+      reason: PipelinesInProgress
+      status: "False"
+      type: ConfigureWorkflowCompleted
   iam:
     user: admin
   message: User created, next step is to create vault secret for user
@@ -152,16 +149,15 @@ The end status would be:
 ```yaml
 status:
   conditions:
-  - lastTransitionTime: "2024-08-21T10:30:51Z"
-    message: Pipelines completed
-    reason: PipelinesExecutedSuccessfully
-    status: "True"
-    type: ConfigureWorkflowCompleted
+    - lastTransitionTime: "2024-08-21T10:30:51Z"
+      message: Pipelines completed
+      reason: PipelinesExecutedSuccessfully
+      status: "True"
+      type: ConfigureWorkflowCompleted
   iam:
     password: <vault-ref>
     user: admin
   message: User created, next step is to create vault secret for user
-
 ```
 
 The status is always merged, with the last Pipeline prioritised in case of
@@ -191,16 +187,27 @@ status:
       type: ConfigureWorkflowCompleted
 ```
 
-Once the Configure workflow has been completed, it will look like:
+Once the Configure workflow has been completed, additional conditions are added:
 
 ```yaml
 status:
   conditions:
-    - lastTransitionTime: "2023-03-07T15:50:30Z"
+    - lastTransitionTime: "2025-06-23T14:07:29Z"
       message: Pipelines completed
       reason: PipelinesExecutedSuccessfully
       status: "True"
       type: ConfigureWorkflowCompleted
+    - lastTransitionTime: "2025-06-23T14:03:24Z"
+      message: All works associated with this resource are ready
+      reason: WorksSucceeded
+      status: "True"
+      type: WorksSucceeded
+    - lastTransitionTime: "2025-06-23T14:07:32Z"
+      message: Reconciled
+      reason: Reconciled
+      status: "True"
+      type: Reconciled
+  lastSuccessfulConfigureWorkflowTime: "2025-06-23T14:07:29Z"
 ```
 
 Conditions can be used by external systems to programmatically check when a

--- a/docs/main/03-reference/15-resources/04-status.md
+++ b/docs/main/03-reference/15-resources/04-status.md
@@ -205,8 +205,9 @@ status:
 ```
 
 Conditions can be used by external systems to programmatically check when a
-workflow has completed. `kubectl` also has built‑in support for waiting for a
-condition to be met. For example, after requesting a Resource you can run:
+Configure workflow has completed. `kubectl` also has built-in support for waiting for a
+condition to be met. For example, after requesting a Resource, a user can run the
+following to have the CLI wait for the Workflow to be completed:
 
 ```bash
 kubectl wait redis/example --for=condition=ConfigureWorkflowCompleted --timeout=60s

--- a/docs/main/03-reference/15-resources/04-status.md
+++ b/docs/main/03-reference/15-resources/04-status.md
@@ -176,21 +176,22 @@ the same as the final status from the previous run of the Configure workflow.
 
 Kratix follows the Kubernetes convention of using
 [conditions](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states)
-to convey the status of a Resource and to allow programmatic interactions.
-Beyond the initial `ConfigureWorkflowCompleted` check, additional conditions
-surface the progress of Works associated with the Resource and when the
-controller has observed the latest version.
+to convey the status of a Resource and to allow programmatic interactions. When
+a Resource is requested, the `ConfigureWorkflowCompleted` condition will be set. The
+`status` for the workflow will be `False` until the workflow is completed. For
+example, when a Resource is requested for the first time, the status will look like:
 
-Common conditions include:
+```yaml
+status:
+  conditions:
+    - lastTransitionTime: "2023-03-07T15:50:22Z"
+      message: Pipelines are still in progress
+      reason: PipelinesInProgress
+      status: "False"
+      type: ConfigureWorkflowCompleted
+```
 
-- `ConfigureWorkflowCompleted` – all Configure workflow pipelines finished successfully.
-- `WorksSucceeded` – every Work created for the Resource completed without errors.
-- `Reconciled` – the controller has observed the most recent version of the Resource.
-
-Kratix also records the timestamp of the last successful configuration in
-`status.lastSuccessfulConfigureWorkflowTime`.
-
-Example output:
+Once the Configure workflow has been completed, it will look like:
 
 ```yaml
 status:
@@ -200,17 +201,7 @@ status:
       reason: PipelinesExecutedSuccessfully
       status: "True"
       type: ConfigureWorkflowCompleted
-    - lastTransitionTime: "2025-06-23T14:03:24Z"
-      message: All works associated with this resource are ready
-      reason: WorksSucceeded
-      status: "True"
-      type: WorksSucceeded
-    - lastTransitionTime: "2025-06-23T14:07:32Z"
-      message: Reconciled
-      reason: Reconciled
-      status: "True"
-      type: Reconciled
-  lastSuccessfulConfigureWorkflowTime: "2025-06-23T14:07:29Z"
+...
 ```
 
 Conditions can be used by external systems to programmatically check when a

--- a/docs/main/03-reference/15-resources/04-status.md
+++ b/docs/main/03-reference/15-resources/04-status.md
@@ -92,20 +92,21 @@ spec:
   workflows:
     resource:
       configure:
-        - apiVersion: platform.kratix.io/v1alpha1
-          kind: Pipeline
-          metadata:
-            name: create-user
-          spec:
-            containers:
-              - image: create-db:v0.1.0
-        - apiVersion: platform.kratix.io/v1alpha1
-          kind: Pipeline
-          metadata:
-            name: populate-vault
-          spec:
-            containers:
-              - image: populate-vault:v0.1.0
+      - apiVersion: platform.kratix.io/v1alpha1
+        kind: Pipeline
+        metadata:
+          name: create-user
+        spec:
+          containers:
+          - image: create-db:v0.1.0
+      - apiVersion: platform.kratix.io/v1alpha1
+        kind: Pipeline
+        metadata:
+          name: populate-vault
+        spec:
+          containers:
+          - image: populate-vault:v0.1.0
+
 ```
 
 And the first pipeline wrote the following to `/kratix/metadata/status.yaml`:
@@ -121,15 +122,17 @@ Then the second pipeline would see the following in the `/kratix/input/object.ya
 ```yaml
 apiVersion: ...
 kind: ...
-metadata: ...
-spec: ...
+metadata:
+  ...
+spec:
+  ...
 status:
   conditions: # this is being automatically set by Kratix
-    - lastTransitionTime: "2024-08-21T10:27:45Z"
-      message: Pipelines are still in progress
-      reason: PipelinesInProgress
-      status: "False"
-      type: ConfigureWorkflowCompleted
+  - lastTransitionTime: "2024-08-21T10:27:45Z"
+    message: Pipelines are still in progress
+    reason: PipelinesInProgress
+    status: "False"
+    type: ConfigureWorkflowCompleted
   iam:
     user: admin
   message: User created, next step is to create vault secret for user
@@ -149,15 +152,16 @@ The end status would be:
 ```yaml
 status:
   conditions:
-    - lastTransitionTime: "2024-08-21T10:30:51Z"
-      message: Pipelines completed
-      reason: PipelinesExecutedSuccessfully
-      status: "True"
-      type: ConfigureWorkflowCompleted
+  - lastTransitionTime: "2024-08-21T10:30:51Z"
+    message: Pipelines completed
+    reason: PipelinesExecutedSuccessfully
+    status: "True"
+    type: ConfigureWorkflowCompleted
   iam:
     password: <vault-ref>
     user: admin
   message: User created, next step is to create vault secret for user
+
 ```
 
 The status is always merged, with the last Pipeline prioritised in case of
@@ -187,27 +191,16 @@ status:
       type: ConfigureWorkflowCompleted
 ```
 
-Once the Configure workflow has been completed, additional conditions are added:
+Once the Configure workflow has been completed, it will look like:
 
 ```yaml
 status:
   conditions:
-    - lastTransitionTime: "2025-06-23T14:07:29Z"
+    - lastTransitionTime: "2023-03-07T15:50:30Z"
       message: Pipelines completed
       reason: PipelinesExecutedSuccessfully
       status: "True"
       type: ConfigureWorkflowCompleted
-    - lastTransitionTime: "2025-06-23T14:03:24Z"
-      message: All works associated with this resource are ready
-      reason: WorksSucceeded
-      status: "True"
-      type: WorksSucceeded
-    - lastTransitionTime: "2025-06-23T14:07:32Z"
-      message: Reconciled
-      reason: Reconciled
-      status: "True"
-      type: Reconciled
-  lastSuccessfulConfigureWorkflowTime: "2025-06-23T14:07:29Z"
 ```
 
 Conditions can be used by external systems to programmatically check when a

--- a/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
@@ -1,22 +1,23 @@
 ---
 title: Promise Status and Events
-description: Understand the status conditions and events generated for a Promise.
+description: Understand the status conditions and events of a Promise.
 id: promise-status-events
 ---
 
-Kratix tracks the lifecycle of each Promise using Kubernetes conditions and events. These describe what phase the Promise is in and surface any actions that may be required.
+Kratix follows the Kubernetes convention of using status and events to convey important information of a Promise.
+Promise Status describes what general condition the Promise is in and surfaces any error that has occurred.
 
 ## Conditions
 
-A Promise exposes several well known conditions:
+A Promise exposes the following list of conditions:
 
-- `RequirementsFulfilled` – Kratix has installed any prerequisites declared by the Promise.
-- `ConfigureWorkflowCompleted` – all Configure workflow pipelines executed successfully.
-- `WorksSucceeded` – every Work created for the Promise has completed.
-- `Available` – the Promise is ready to accept Resource requests.
-- `Reconciled` – the reconciler has observed the latest version of the Promise.
+- `RequirementsFulfilled` – Kratix has installed any required Promises declared by the Promise.
+- `ConfigureWorkflowCompleted` – All configure workflow pipelines executed successfully.
+- `WorksSucceeded` – All Works created for the Promise has completed.
+- `Available` – The Promise is ready to accept Resource requests.
+- `Reconciled` – Promise has been successfully reconciled; Set to true when all the above conditions are all true.
 
-Example output from `kubectl get promise <name> -o yaml`:
+Example Promise conditions from `kubectl get promise <name> -o yaml`:
 
 ```yaml
 status:
@@ -48,15 +49,33 @@ status:
     type: Reconciled
 ```
 
-Inspect the current status at any time with:
+Inspect the current Promise status at any time with:
 
 ```bash
 kubectl describe promise <name>
 ```
 
+## Common Promise Status
+
+- `apiVersion` – Shows the API version that this Promise is serving requests at.
+- `kind` – Shows the Kind that this Promise is serving.
+- `lastAvailableTime` – When this Promise becomes available.
+- `status` – Whether the Promise is ready to accept Resource requests; can be set to 'Available' or 'Unavailable'.
+
+```yaml
+status:
+  apiVersion: test.kratix.io/v1alpha1
+  kind: Redis
+  lastAvailableTime: "2025-06-23T15:34:32Z"
+  status: Available
+  conditions:
+  ...
+```
+
 ## Events
 
-Events record important moments in the Promise lifecycle such as requirements installation, Work creation and when the Promise becomes available. They can be viewed using:
+Events record important moments in the Promise lifecycle such as requirements installation, Configure pipeline running and when the Promise becomes available.
+They can be viewed using:
 
 ```bash
 kubectl describe promise <name>

--- a/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
@@ -12,10 +12,10 @@ Promise Status describes what general condition the Promise is in and surfaces a
 A Promise exposes the following list of conditions:
 
 - `RequirementsFulfilled` – Kratix has installed any required Promises declared by the Promise.
-- `ConfigureWorkflowCompleted` – All configure workflow pipelines executed successfully.
-- `WorksSucceeded` – All Works created for the Promise has completed.
-- `Available` – The Promise is ready to accept Resource requests.
-- `Reconciled` – Promise has been successfully reconciled; Set to true when all the above conditions are all true.
+- `ConfigureWorkflowCompleted` – all configure workflow pipelines executed successfully.
+- `WorksSucceeded` – all Works created for the Promise has completed.
+- `Available` – Promise is ready to accept Resource requests.
+- `Reconciled` – Promise has been successfully reconciled; set to true when all the above conditions are all true.
 
 Example Promise conditions from `kubectl get promise <name> -o yaml`:
 

--- a/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
@@ -1,0 +1,65 @@
+---
+title: Promise Status and Events
+description: Understand the status conditions and events generated for a Promise.
+id: promise-status-events
+---
+
+Kratix tracks the lifecycle of each Promise using Kubernetes conditions and events. These describe what phase the Promise is in and surface any actions that may be required.
+
+## Conditions
+
+A Promise exposes several well known conditions:
+
+- `RequirementsFulfilled` – Kratix has installed any prerequisites declared by the Promise.
+- `ConfigureWorkflowCompleted` – all Configure workflow pipelines executed successfully.
+- `WorksSucceeded` – every Work created for the Promise has completed.
+- `Available` – the Promise is ready to accept Resource requests.
+- `Reconciled` – the reconciler has observed the latest version of the Promise.
+
+Example output from `kubectl get promise <name> -o yaml`:
+
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2025-06-23T14:02:27Z"
+    message: Requirements fulfilled
+    reason: RequirementsInstalled
+    status: "True"
+    type: RequirementsFulfilled
+  - lastTransitionTime: "2025-06-23T14:07:23Z"
+    message: Pipelines completed
+    reason: PipelinesExecutedSuccessfully
+    status: "True"
+    type: ConfigureWorkflowCompleted
+  - lastTransitionTime: "2025-06-23T14:02:40Z"
+    message: All works associated with this promise are ready
+    reason: WorksSucceeded
+    status: "True"
+    type: WorksSucceeded
+  - lastTransitionTime: "2025-06-23T14:07:26Z"
+    message: Ready to fulfil resource requests
+    reason: PromiseAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2025-06-23T14:07:26Z"
+    message: Reconciled
+    reason: Reconciled
+    status: "True"
+    type: Reconciled
+```
+
+Inspect the current status at any time with:
+
+```bash
+kubectl describe promise <name>
+```
+
+## Events
+
+Events record important moments in the Promise lifecycle such as requirements installation, Work creation and when the Promise becomes available. They can be viewed using:
+
+```bash
+kubectl describe promise <name>
+```
+
+These events are useful for understanding the progression of the Promise and troubleshooting failures.

--- a/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/01-promise-status-events.mdx
@@ -4,7 +4,7 @@ description: Understand the status conditions and events of a Promise.
 id: promise-status-events
 ---
 
-Kratix follows the Kubernetes convention of using status and events to convey important information of a Promise.
+Kratix follows the Kubernetes convention of using status and events to convey important information about a Promise.
 Promise Status describes what general condition the Promise is in and surfaces any error that has occurred.
 
 ## Conditions
@@ -55,7 +55,7 @@ Inspect the current Promise status at any time with:
 kubectl describe promise <name>
 ```
 
-## Common Promise Status
+## Common Promise Status Fields
 
 - `apiVersion` – Shows the API version that this Promise is serving requests at.
 - `kind` – Shows the Kind that this Promise is serving.
@@ -74,7 +74,9 @@ status:
 
 ## Events
 
-Events record important moments in the Promise lifecycle such as requirements installation, Configure pipeline running and when the Promise becomes available.
+Events record important moments in the Promise lifecycle such as when requirements are installed,
+if the configure pipeline is running and when the Promise becomes available.
+
 They can be viewed using:
 
 ```bash

--- a/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
@@ -7,7 +7,6 @@ id: resource-status-events
 Kratix follows the Kubernetes convention of using status and events to convey the status of a Resource and to allow
 programmatic interactions.
 
-
 ## Conditions
 
 Resources have the following list of conditions:

--- a/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
@@ -1,0 +1,46 @@
+---
+title: Resource Status and Events
+description: Learn about the conditions and events attached to Resource requests.
+id: resource-status-events
+---
+
+Resources expose progress information through status conditions. Common conditions include:
+
+- `ConfigureWorkflowCompleted` – all Configure workflow pipelines finished successfully.
+- `WorksSucceeded` – every Work created for the Resource completed without errors.
+- `Reconciled` – the controller has observed the latest version of the Resource.
+
+A Resource also records the time of the last successful configuration in `status.lastSuccessfulConfigureWorkflowTime`.
+
+Example output:
+
+```yaml
+status:
+  conditions:
+  - lastTransitionTime: "2025-06-23T14:07:29Z"
+    message: Pipelines completed
+    reason: PipelinesExecutedSuccessfully
+    status: "True"
+    type: ConfigureWorkflowCompleted
+  - lastTransitionTime: "2025-06-23T14:07:32Z"
+    message: Reconciled
+    reason: Reconciled
+    status: "True"
+    type: Reconciled
+  - lastTransitionTime: "2025-06-23T14:03:24Z"
+    message: All works associated with this resource are ready
+    reason: WorksSucceeded
+    status: "True"
+    type: WorksSucceeded
+  lastSuccessfulConfigureWorkflowTime: "2025-06-23T14:07:29Z"
+```
+
+## Events
+
+Events note important steps in the Resource lifecycle such as starting a workflow job or encountering errors. Inspect them with:
+
+```bash
+kubectl describe <resource> <name>
+```
+
+These events help in troubleshooting and automation around Resource management.

--- a/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
@@ -4,13 +4,17 @@ description: Learn about the conditions and events attached to Resource requests
 id: resource-status-events
 ---
 
-Kratix follows the Kubernetes convention of using conditions to convey the status of a Resource and to allow programmatic interactions. . Common conditions include:
+Kratix follows the Kubernetes convention of using status and events to convey the status of a Resource and to allow
+programmatic interactions.
+
+
+## Conditions
+
+Resources have the following list of conditions:
 
 - `ConfigureWorkflowCompleted` – all Configure workflow pipelines finished successfully.
-- `WorksSucceeded` – every Work created for the Resource completed without errors.
-- `Reconciled` – the controller has observed the latest version of the Resource.
-
-A Resource also records the time of the last successful configuration in `status.lastSuccessfulConfigureWorkflowTime`.
+- `WorksSucceeded` – every Work created for the Resource has completed.
+- `Reconciled` – Resource has been successfully reconciled; set to true when all the above conditions are all true.
 
 Example output:
 
@@ -35,6 +39,10 @@ status:
   lastSuccessfulConfigureWorkflowTime: "2025-06-23T14:07:29Z"
 ```
 
+## Last Successful ConfigureWorkflow
+
+A Resource also records the time of the last successful Configure workflow run in `status.lastSuccessfulConfigureWorkflowTime`.
+
 ## Events
 
 Events note important steps in the Resource lifecycle such as starting a workflow job or encountering errors. Inspect them with:
@@ -43,4 +51,4 @@ Events note important steps in the Resource lifecycle such as starting a workflo
 kubectl describe <resource> <name>
 ```
 
-These events help in troubleshooting and automation around Resource management.
+These events help in troubleshooting and understanding the status of your Resource requests.

--- a/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/02-resource-status-events.mdx
@@ -4,7 +4,7 @@ description: Learn about the conditions and events attached to Resource requests
 id: resource-status-events
 ---
 
-Resources expose progress information through status conditions. Common conditions include:
+Kratix follows the Kubernetes convention of using conditions to convey the status of a Resource and to allow programmatic interactions. . Common conditions include:
 
 - `ConfigureWorkflowCompleted` – all Configure workflow pipelines finished successfully.
 - `WorksSucceeded` – every Work created for the Resource completed without errors.

--- a/docs/main/05-learn-more/03-status-conditions-events/03-work-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/03-work-status-events.mdx
@@ -1,0 +1,72 @@
+---
+title: Work and WorkPlacement Status and Events
+description: Understand the status conditions and events generated for Work and WorkPlacement objects.
+id: work-status-events
+---
+
+A **Work** represents the output of a workflow. Each Work is scheduled to one or more Destinations and its progress is tracked through conditions. A **WorkPlacement** ties part of a Work to a specific Destination and records whether the documents were written successfully.
+
+## Work Conditions
+
+Works expose the following conditions:
+
+- `ScheduleSucceeded` – set to `True` once all WorkPlacements have been created. If Kratix cannot find matching Destinations this condition is `False` with reason `UnscheduledWorkloadGroups`.
+- `Ready` – becomes `True` when every WorkPlacement has been scheduled successfully.
+
+Example output from `kubectl get work <name> -o yaml`:
+
+```yaml
+status:
+  conditions:
+    - lastTransitionTime: "2025-06-23T14:03:20Z"
+      message: All workplacements scheduled successfully
+      reason: AllWorkplacementsScheduled
+      status: "True"
+      type: ScheduleSucceeded
+    - lastTransitionTime: "2025-06-23T14:03:20Z"
+      message: Ready
+      reason: AllWorkplacementsScheduled
+      status: "True"
+      type: Ready
+```
+
+## WorkPlacement Conditions
+
+A WorkPlacement records whether its documents were written to the Destination:
+
+- `ScheduleSucceeded` – `True` when the WorkPlacement has been scheduled to a Destination.
+- `WriteSucceeded` – indicates the documents were written to the State Store backing the Destination.
+- `Ready` – `True` when the Destination accepted the documents.
+
+Example output from `kubectl get workplacement <name> -o yaml`:
+
+```yaml
+status:
+  conditions:
+    - lastTransitionTime: "2025-06-23T14:03:20Z"
+      message: Scheduled to correct Destination
+      reason: ScheduledToDestination
+      status: "True"
+      type: ScheduleSucceeded
+    - lastTransitionTime: "2025-06-23T14:03:20Z"
+      message: Ready
+      reason: WorkloadsWrittenToTargetDestination
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2025-06-23T14:03:20Z"
+      message: ""
+      reason: WorkloadsWrittenToStateStore
+      status: "True"
+      type: WriteSucceeded
+```
+
+## Events
+
+Events on Works and WorkPlacements highlight scheduling progress and any issues writing to Destinations. Use:
+
+```bash
+kubectl describe work <name>
+kubectl describe workplacement <name>
+```
+
+to inspect recent events.

--- a/docs/main/05-learn-more/03-status-conditions-events/03-work-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/03-work-status-events.mdx
@@ -4,14 +4,18 @@ description: Understand the status conditions and events generated for Work and 
 id: work-status-events
 ---
 
-A **Work** represents the output of a workflow. Each Work is scheduled to one or more Destinations and its progress is tracked through conditions. A **WorkPlacement** ties part of a Work to a specific Destination and records whether the documents were written successfully.
+A **Work** represents the output of a workflow. Each Work is scheduled to one or more Destinations.
+Its progress is tracked through conditions.
+
+A **WorkPlacement** ties part of a Work to a specific Destination.
+Its status shows whether the documents were written successfully.
 
 ## Work Conditions
 
 Works expose the following conditions:
 
 - `ScheduleSucceeded` – set to `True` once all WorkPlacements have been created. If Kratix cannot find matching Destinations this condition is `False` with reason `UnscheduledWorkloadGroups`.
-- `Ready` – becomes `True` when every WorkPlacement has been scheduled successfully.
+- `Ready` – set to `True` when every WorkPlacement has been scheduled successfully.
 
 Example output from `kubectl get work <name> -o yaml`:
 
@@ -32,11 +36,11 @@ status:
 
 ## WorkPlacement Conditions
 
-A WorkPlacement records whether its documents were written to the Destination:
+WorkPlacements expose the following conditions:
 
-- `ScheduleSucceeded` – `True` when the WorkPlacement has been scheduled to a Destination.
+- `ScheduleSucceeded` – `True` when the WorkPlacement has been scheduled to a matching Destination.
 - `WriteSucceeded` – indicates the documents were written to the State Store backing the Destination.
-- `Ready` – `True` when the Destination accepted the documents.
+- `Ready` – `True` when both `ScheduleSucceeded` and `WriteSucceeded` are true.
 
 Example output from `kubectl get workplacement <name> -o yaml`:
 
@@ -62,11 +66,11 @@ status:
 
 ## Events
 
-Events on Works and WorkPlacements highlight scheduling progress and any issues writing to Destinations. Use:
+Events on Works and WorkPlacements highlight scheduling progress and any issues writing to Destinations.
+
+Run the following commands to inspect Works and Workplacements events:
 
 ```bash
 kubectl describe work <name>
 kubectl describe workplacement <name>
 ```
-
-to inspect recent events.

--- a/docs/main/05-learn-more/03-status-conditions-events/03-work-status-events.mdx
+++ b/docs/main/05-learn-more/03-status-conditions-events/03-work-status-events.mdx
@@ -1,5 +1,5 @@
 ---
-title: Work and WorkPlacement Status and Events
+title: Work, WorkPlacement Status and Events
 description: Understand the status conditions and events generated for Work and WorkPlacement objects.
 id: work-status-events
 ---

--- a/docs/main/05-learn-more/03-status-conditions-events/_category_.json
+++ b/docs/main/05-learn-more/03-status-conditions-events/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Status Conditions & Events",
+  "position": 3
+}


### PR DESCRIPTION
## Summary
- add combined Work and WorkPlacement status docs
- update Resource status documentation with new conditions
- extend Quick Start example with WorksSucceeded and Reconciled

closes: https://github.com/syntasso/kratix-docs/issues/278

## Testing
- `yarn build` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.8.1/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_b_6859643799688328ab8ed697a46fe3c2