### PR TITLE
docs: links to ske gui videos in docs

### DIFF
--- a/docs/ske/01-installing-ske/50-ske-gui.mdx
+++ b/docs/ske/01-installing-ske/50-ske-gui.mdx
@@ -9,6 +9,10 @@ It introduces a clear, unified view of your entire platform, giving platform eng
 
 This page provides information on how to install the SKE GUI. For documentation on how to use the GUI, please refer to [SKE GUI usage guide](/ske/guides/ske-gui).
 
+<div style={{"text-align":"center"}}>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/8P3eA_FRt0Y?si=M24UWf8ZEjUDKrKO" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
 ## Installation Steps
 
 The GUI is released separately from SKE. Its releases can be found [in the SKE GUI release page](/ske/releases/ske-gui) and it can be installed using the [helm chart](https://github.com/syntasso/helm-charts/tree/main/ske-gui).

--- a/docs/ske/05-guides/12-ske-gui.mdx
+++ b/docs/ske/05-guides/12-ske-gui.mdx
@@ -9,6 +9,12 @@ It introduces a clear, unified view of your entire platform, giving platform eng
 
 This page provides information on how to use the SKE GUI. For documentation on how to install it, please refer to the [installation guide](/ske/installing-ske/ske-gui).
 
+You can refer to this video for a walk through of how to use the GUI:
+
+<div style={{"text-align":"center"}}>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lLxT0mKXgA8?si=Awm6FDzbUAPNZk6h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
 ## The Promise Views {#promises}
 
 When you access the SKE GUI, you should see the Kratix Sidebar entry on the left. When you click on this entry, you will see a list of all the Kratix Promises.


### PR DESCRIPTION
## Description

We have videos that shows GUI install and GUI usage, link to them in the doc pages.

## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
