### PR TITLE
document skopeo workaround

### DIFF
--- a/docs/ske/01-installing-ske/03-air-gapped.mdx
+++ b/docs/ske/01-installing-ske/03-air-gapped.mdx
@@ -66,11 +66,11 @@ registry via `ghcr.io` rather than `registry.syntasso.io`**, because Skopeo does
 correctly follow redirect responses used by the latter.
 
 
-Below is an example of copyying the image `registry.syntasso.io/syntasso/ske-operator:v0.17.0` to
+Below is an example of copying the image `registry.syntasso.io/syntasso/ske-operator:v0.17.0` to
 your own registry, substituting ghcr.io as the source:
 
 ```bash
-skopeo copy --retry-times=2 --all --src-creds=syntasso-pkg:${SYNTASSO_TOKEN} --dest-creds=${MIRROR_USERNAME}:${MIRROR_PWD} docker://ghcr.io/syntasso/ske-operator:v0.17.0 docker://${SYNTASSO_DST}
+skopeo copy --retry-times=2 --all --src-creds=syntasso-pkg:${SYNTASSO_TOKEN} --dest-creds=${MIRROR_USERNAME}:${MIRROR_PWD} docker://ghcr.io/syntasso/ske-operator:v0.17.0 docker://registry.my-org.com/syntasso/ske-operator:v0.17.0
 ```
 
 :::


### PR DESCRIPTION
skopeo doens't work with registry redirects

<img width="1518" height="861" alt="Screenshot 2025-10-13 at 16 03 26" src="https://github.com/user-attachments/assets/068afc80-7fb7-44ac-9623-21515bdf2453" />
