### PR TITLE
chore: example config was wrong for backofflimit

### DIFF
--- a/docs/main/03-reference/17-kratix-config/kratix-config.md
+++ b/docs/main/03-reference/17-kratix-config/kratix-config.md
@@ -24,10 +24,6 @@ data:
   config: |
     # Number of old successful pipeline pods to keep. Default is 5
     numberOfJobsToKeep: 1
-    # Number of times Kubernetes retries a failing workflow Job before marking it failed.
-    # Kratix does not set a default for this field, so Kubernetes uses its own
-    # Job default (6) if it is omitted.
-    backoffLimit: 4
     # Selective cache for Secrets to limit memory usage. Please ensure Secrets used by Kratix are
     # created with label: app.kubernetes.io/part-of=kratix. Default is false.
     selectiveCache: false
@@ -39,6 +35,11 @@ data:
       renewDeadline: 10s
       retryPeriod: 2s
     workflows:
+      jobOptions:
+        # Number of times Kubernetes retries a failing workflow Job before marking it failed.
+        # Kratix does not set a default for this field, so Kubernetes uses its own
+        # Job default (6) if it is omitted.
+        defaultBackoffLimit: 4
       defaultImagePullPolicy: # can be `IfNotPresent`, `Always`, or `Never`
       defaultContainerSecurityContext:
         # Security context fields, e.g.:


### PR DESCRIPTION


## Description
- default backoff limit is under jobOptions

