### PR TITLE
fix: clarify which values should be forced to be strings

### DIFF
--- a/docs/ske/01-installing-ske/40-ske-health-agent.mdx
+++ b/docs/ske/01-installing-ske/40-ske-health-agent.mdx
@@ -153,8 +153,8 @@ metadata:
   name: <secret name>
   namespace: k8s-health-agent-system
 stringData:
-  accesskey: # Access Key ID
-  secretkey: # Secret Access Key
+  accessKeyID: # Access Key ID
+  secretAccessKey: # Secret Access Key
 ```
 
 :::warning


### PR DESCRIPTION
Access/Secret Key fields did not match what was required. Also clarified that the value for `insecure` needs to be a string.

## Description


## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
