### PR TITLE
chore: shift to using latest in docs for SKE installs

### DIFF
--- a/docs/ske/01-installing-ske/01-preconfigured-install.mdx
+++ b/docs/ske/01-installing-ske/01-preconfigured-install.mdx
@@ -72,7 +72,7 @@ kubectl create secret docker-registry syntasso-registry \
 Then apply the SKE installer manifest:
 
 ```bash
-kubectl apply -f http://s3.eu-west-2.amazonaws.com/syntasso-enterprise-releases/ske/v0.31.0/dev-only/ske-quick-start-installer.yaml
+kubectl apply -f http://s3.eu-west-2.amazonaws.com/syntasso-enterprise-releases/ske/latest/dev-only/ske-quick-start-installer.yaml
 ```
 
 This will deploy a job that installs SKE and its dependencies. To follow along

--- a/docs/ske/01-installing-ske/03-air-gapped.mdx
+++ b/docs/ske/01-installing-ske/03-air-gapped.mdx
@@ -66,11 +66,11 @@ registry via `ghcr.io` rather than `registry.syntasso.io`**, because Skopeo does
 correctly follow redirect responses used by the latter.
 
 
-Below is an example of copying the image `registry.syntasso.io/syntasso/ske-operator:v0.17.0` to
+Below is an example of copying the image `registry.syntasso.io/syntasso/ske-operator:latest` to
 your own registry, substituting ghcr.io as the source:
 
 ```bash
-skopeo copy --retry-times=2 --all --src-creds=syntasso-pkg:${SYNTASSO_TOKEN} --dest-creds=${MIRROR_USERNAME}:${MIRROR_PWD} docker://ghcr.io/syntasso/ske-operator:v0.17.0 docker://registry.my-org.com/syntasso/ske-operator:v0.17.0
+skopeo copy --retry-times=2 --all --src-creds=syntasso-pkg:${SYNTASSO_TOKEN} --dest-creds=${MIRROR_USERNAME}:${MIRROR_PWD} docker://ghcr.io/syntasso/ske-operator:latest docker://registry.my-org.com/syntasso/ske-operator:latest
 ```
 
 :::


### PR DESCRIPTION
## Description
This line of docs is getting out of date. Setting to latest to keep it in working order and allowing users to pin to a version if they choose.
