### PR TITLE
bug: fix bash preserve error. Add healthStatus nested property to cor…

### DIFF
--- a/assets/redis-health-check-image/wait-healthy
+++ b/assets/redis-health-check-image/wait-healthy
@@ -4,8 +4,8 @@ namespace="$(yq '.metadata.namespace // "default"' /kratix/input/object.yaml)"
 resourceName="$(yq '.metadata.name' /kratix/input/object.yaml)"
 
 while true; do
-  state="$(kubectl get redis ${resourceName} --namespace ${namespace} -o jsonpath='{.status.healthRecord.state}')"
-  if [[ ${state} == "healthy" ]]; then 
+  state="$(kubectl get redis ${resourceName} --namespace ${namespace} -o jsonpath='{status.healthStatus.healthRecords[0].state}')"
+  if [[ "${state}" == "healthy" ]]; then
     break
   fi
   echo "Waiting for resource to be healthy, current state: ${state:-"unknown"}"


### PR DESCRIPTION
Summary

Update the Redis health check jsonpath and harden the state comparison.

What changed
	•	Updated the kubectl jsonpath from:

`{.status.healthRecord.state}`

to:

`{status.healthStatus.healthRecords[0].state}`

This reflects the current object structure where state now lives under status.healthStatus.healthRecords[0].

	•	Quoted the ${state} variable in the conditional:

if [[ "${state}" == "healthy" ]]; then

This prevents word splitting or glob expansion if the value is empty or contains unexpected characters.

Why
	•	The health record schema has moved from a flat healthRecord field to a nested healthStatus.healthRecords array.
	•	The script now reads the state from the first health record entry.
	•	Quoting ${state} makes the comparison safer and more robust.

Impact

No behavioural change when the resource is healthy.
Improves correctness against the current schema and avoids subtle bash edge cases.

No Issue was created for this bug. 