### PR TITLE
Use GITHUB_TOKEN for GHCR asset publish

### DIFF
--- a/.github/workflows/build-and-push-assets.yml
+++ b/.github/workflows/build-and-push-assets.yml
@@ -8,6 +8,10 @@ on:
     - scripts/build-and-push-assets
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -16,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build and push assets
         run: |
-          echo "${GITHUB_TOKEN}" | docker login --username syntassodev --password-stdin ghcr.io
+          echo "${GITHUB_TOKEN}" | docker login --username "${{ github.actor }}" --password-stdin ghcr.io
           ./scripts/build-and-push-assets
         env:
-          GITHUB_TOKEN: ${{ secrets.REGISTRY_PUSH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- switch GHCR publish login from `syntassodev` PAT to workflow `GITHUB_TOKEN`
- keep scope to same-repo publish paths only
- add `permissions.packages: write` where missing

## Why
- ensures new GHCR packages are associated to the source repository
- removes dependence on elevated `syntassodev` permissions for publish flows
