### PR TITLE
docs: document podTTLSecondsAfterFinished feature

### DIFF
--- a/docs/main/03-reference/19-kratix-config/kratix-config.md
+++ b/docs/main/03-reference/19-kratix-config/kratix-config.md
@@ -34,6 +34,7 @@ data:
     workflows:
       jobOptions:
         defaultBackoffLimit: 6
+        podTTLSecondsAfterFinished: 3600
       defaultImagePullPolicy: IfNotPresent # can be `IfNotPresent`, `Always`, or `Never`
       defaultContainerSecurityContext:
         runAsNonRoot: false
@@ -83,6 +84,12 @@ Options for the Jobs that are created by Kratix Workflows.
 ##### defaultBackoffLimit
 
 The number of times to retry a failing workflow Job before marking it failed. This configures the [backoffLimit](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) in Workflow Jobs. This will default to the Kubernetes Job default of 6.
+
+##### podTTLSecondsAfterFinished
+
+podTTLSecondsAfterFinished limits the lifetime of workflow Jobs Pods that has finished execution (either Complete or Failed).
+If this field is set, podTTLSecondsAfterFinished after the Job finishes, Kratix will automatically clean up its Pods.
+Value of podTTLSecondsAfterFinished has to be greater than 0, or else it's ignored.
 
 #### defaultImagePullPolicy
 


### PR DESCRIPTION
## Description
This relates to issue https://github.com/syntasso/kratix/issues/702
Merge this PR after this feature is released: https://github.com/syntasso/kratix/pull/719

## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Document podTTLSecondsAfterFinished configuration option for automatic cleanup of completed workflow Job Pods in Kratix.
Main changes:
- Added podTTLSecondsAfterFinished field to jobOptions configuration example with default value of 3600 seconds
- Documented podTTLSecondsAfterFinished parameter behavior for automatic Pod cleanup after workflow Jobs complete or fail
- Specified validation requirement that podTTLSecondsAfterFinished value must be greater than 0 to take effect

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
