### PR TITLE
docs: document status.kratix for resource and promise

### DIFF
--- a/docs/main/03-reference/11-promises/09-status-events.mdx
+++ b/docs/main/03-reference/11-promises/09-status-events.mdx
@@ -78,6 +78,35 @@ status:
     version: v0.1.0
 ```
 
+## Pipeline Execution Status Fields
+
+Kratix executes Configure Workflow pipelines in order and records the state of each pipeline under `status.kratix.workflows.pipelines`.
+
+For example, if a Promise has three configure pipelines and the third pipeline is currently running, the status could look like:
+
+```yaml
+status:
+  kratix:
+    workflows:
+      lastSuccessfulConfigureWorkflowTime: "2026-03-16T11:52:06Z"
+      pipelines:
+        - name: pipeline0
+          phase: Succeeded
+          lastTransitionTime: "2026-03-16T11:53:04Z"
+        - name: pipeline1
+          phase: Succeeded
+          lastTransitionTime: "2026-03-16T11:53:05Z"
+        - name: pipeline2
+          phase: Running
+          lastTransitionTime: "2026-03-16T11:53:57Z"
+```
+
+Each pipeline can be in one of these phases: `Pending`, `Running`, `Succeeded`, or `Failed`.
+
+`lastTransitionTime` is updated whenever the pipeline phase changes. If a pipeline enters the `Failed` phase, Kratix stops executing the remaining pipelines in that workflow. When a new configure reconciliation starts, Kratix resets all pipeline phases to `Pending` before running the workflow again.
+
+For more detail about a failed pipeline, inspect the events on the Promise and the logs of the failed pipeline Job.
+
 ## Events
 
 Events record important moments in the Promise lifecycle such as when requirements are installed,

--- a/docs/main/03-reference/15-resources/06-status-events.mdx
+++ b/docs/main/03-reference/15-resources/06-status-events.mdx
@@ -46,9 +46,38 @@ status:
 ## Common Resource Status Fields
 
 - `kratix.workflows.lastSuccessfulConfigureWorkflowTime` – The time of the last successful Configure workflow run
-- `workflows` - The number of Promise configure workflow pipelines
-- `workflowsSucceeded` - The number of Promise configure workflow pipelines that have completed successfully
-- `workflowsFailed`- The number of Promise configure workflow pipelines that have failed
+- `workflows` - The number of Resource configure workflow pipelines
+- `workflowsSucceeded` - The number of Resource configure workflow pipelines that have completed successfully
+- `workflowsFailed`- The number of Resource configure workflow pipelines that have failed
+
+## Pipeline Execution Status Fields
+
+Kratix executes Resource Configure Workflow pipelines in order and records the state of each pipeline under `status.kratix.workflows.pipelines`.
+
+For example, if a Resource Configure Workflow has three pipelines and the second pipeline is currently running, the status could look like:
+
+```yaml
+status:
+  kratix:
+    workflows:
+      lastSuccessfulConfigureWorkflowTime: "2026-03-16T11:52:06Z"
+      pipelines:
+        - name: resource-pipeline0
+          phase: Succeeded
+          lastTransitionTime: "2026-03-16T11:53:04Z"
+        - name: resource-pipeline1
+          phase: Running
+          lastTransitionTime: "2026-03-16T11:53:05Z"
+        - name: resource-pipeline2
+          phase: Pending
+          lastTransitionTime: "2026-03-16T11:52:57Z"
+```
+
+Each pipeline can be in one of these phases: `Pending`, `Running`, `Succeeded`, or `Failed`.
+
+`lastTransitionTime` is updated whenever the pipeline phase changes. If a pipeline enters the `Failed` phase, Kratix stops executing the remaining pipelines in that workflow. When a new configure reconciliation starts, Kratix resets all pipeline phases to `Pending` before running the workflow again.
+
+For more detail about a failed pipeline, inspect the events on the resource and the logs of the failed pipeline Job.
 
 ## Events
 


### PR DESCRIPTION
## Description

- related to https://github.com/syntasso/kratix/issues/676

Pending PR. We might want to hold off updating til this track is finished?

## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update documentation to reflect new status.kratix namespace structure for Promise and Resource status fields in Kratix API.

Main changes:
- Moved Promise status fields (apiVersion, kind, lastAvailableTime, status) under kratix namespace prefix
- Relocated Resource lastSuccessfulConfigureWorkflowTime field to kratix.workflows nested structure
- Updated documentation examples with corrected YAML structure and field paths for both resource types

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
