### PR TITLE
feat: follow browser color preference for light/dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,6 +144,9 @@ const config = {
           hideable: true,
         },
       },
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
       navbar: {
         logo: {
           alt: "Kratix Logo",


### PR DESCRIPTION
Our website currently does not follow the browser hints to select light or dark mode automatically. This change enables the Docusaurus support for this. Local test shows that it does what it is supposed to.
