### PR TITLE
docs: add tfstate-finder v0.8.0 release notes and GHCR notice

### DIFF
--- a/docs/ske/50-releases/30-pipeline-stages/20-tfstate-finder.mdx
+++ b/docs/ske/50-releases/30-pipeline-stages/20-tfstate-finder.mdx
@@ -27,6 +27,16 @@ will fail to pull the image within their Workflows
 
 ## Release Notes
 
+### [v0.8.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#aspects/ske-tfstate-finder/v0.8.0/) (2026-03-18)
+
+#### Security Fixes
+
+* Updated to include latest security updates.
+
+#### Important
+
+* As of `v0.8.0`, `tf-state-finder` is published to `ghcr.io` instead of `registry.syntasso.io`.
+
 ### [v0.7.4](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#aspects/ske-tfstate-finder/v0.7.4/) (2026-02-18)
 
 #### Bug Fixes


### PR DESCRIPTION
## Summary
- add `v0.8.0` release notes for `ske-tfstate-finder`
- include security update note for the release
- document that `tf-state-finder` is now published at `ghcr.io` (not `registry.syntasso.io`)
- warn that registry secrets must be updated or Promise Workflows will fail to pull the image

## Validation
- `yarn build`
