### PR TITLE
ci: add dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Adds `dependabot.yml` covering npm deps (root) and GitHub Actions
- Weekly schedule (Mondays) to reduce noise
- All updates grouped into a single PR per ecosystem — replaces the current flood of individual security PRs

## Test plan

- [ ] Verify Dependabot picks up the config (should appear in repo Security > Dependabot tab)
- [ ] Confirm grouped PRs appear next Monday rather than individual ones
- [ ] Existing open Dependabot PRs (#480–#484) can be closed once this is merged and Dependabot regenerates them grouped