### PR TITLE
docs: add v0.48.0 SKE release notes

### DIFF
--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -23,9 +23,7 @@ Check the release notes below for information on each available version.
 
 #### Features
 
-* Support selectively skipping Cortex workflow generation (create, update, delete) per Promise using the `kratix.io/cortex-skip-workflows` annotation.
 * Support upgrading resources via an UpgradeRun.
-* Support configuring additional `volumes` and `volumeMounts` on the Kratix deployment via `spec.deploymentConfig` in the SKE Operator.
 * Workflow status is now surfaced on Resource Bindings.
 * Introduce a platform-wide `resourceBindings.defaultVersion` setting in the Kratix Config to control whether new Resource Bindings pin to a specific version (`pinned`) or track latest (`floating`, default).
 * Resource Bindings can be reconciled on-demand using the `kratix.io/reconcile` label.

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -23,7 +23,6 @@ Check the release notes below for information on each available version.
 
 #### Features
 
-* Support upgrading resources via an UpgradeRun.
 * Workflow status is now surfaced on Resource Bindings.
 * Introduce a platform-wide `resourceBindings.defaultVersion` setting in the Kratix Config to control whether new Resource Bindings pin to a specific version (`pinned`) or track latest (`floating`, default).
 * Resource Bindings can be reconciled on-demand using the `kratix.io/reconcile` label.

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,34 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [v0.48.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.48.0/) (TBD)
+
+#### Features
+
+* Support selectively skipping Cortex workflow generation (create, update, delete) per Promise using the `kratix.io/cortex-skip-workflows` annotation.
+* Support upgrading resources via an UpgradeRun.
+* Support configuring additional `volumes` and `volumeMounts` on the Kratix deployment via `spec.deploymentConfig` in the SKE Operator.
+* Workflow status is now surfaced on Resource Bindings.
+* Introduce a platform-wide `resourceBindings.defaultVersion` setting in the Kratix Config to control whether new Resource Bindings pin to a specific version (`pinned`) or track latest (`floating`, default).
+* Resource Bindings can be reconciled on-demand using the `kratix.io/reconcile` label.
+* Pipeline Jobs now carry an owner reference to their parent resource or Promise, making job-to-resource relationships discoverable.
+* Unpausing a Resource Request no longer triggers an unnecessary reconciliation.
+
+#### Fixes
+
+* Fixed: invalid Resource Binding version no longer prevents resource deletion.
+* `UpgradeFailed` status now propagates correctly to Resource Bindings.
+* Fixed inconsistent upgrade status for Resource Bindings during promise upgrades.
+* Improved error message when an SSH private key is missing from the configured Secret.
+
+#### Security Fixes
+
+* Updated `golang.org/x/crypto` and `golang.org/x/net` dependencies to address recent CVEs.
+
+#### Maintenance
+
+* Base image updates and package maintenance.
+
 ### [v0.47.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.47.0/) (2026-05-18)
 
 #### Features

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,7 +19,7 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
-### [v0.48.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.48.0/) (TBD)
+### [v0.48.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.48.0/) (2026-06-03)
 
 #### Features
 


### PR DESCRIPTION
## Summary

- Adds v0.48.0 release notes entry to `docs/ske/50-releases/10-ske.mdx`
- Covers: Cortex skip-workflows annotation, UpgradeRun resource upgrades, SKE Operator volumes/volumeMounts, Resource Binding improvements (workflow status, version strategy, reconcile label, owner references on pipeline jobs), bug fixes, security dep updates

## Notes for reviewer

- The "Support upgrading resources via an UpgradeRun" bullet (feat #979) needs verification — the PR body was unavailable when drafting. Please confirm the user-facing description is accurate.
- Date is TBD — update to actual release date before merging.
- `kratix.io/reconcile` label for Resource Bindings (#806) — confirm this is a new label vs one that already existed for Promises.

## Test plan

- [ ] Verify release notes render correctly in docs site
- [ ] Confirm PR #979 description is accurate
- [ ] Replace TBD date with actual release date before merging