### PR TITLE
docs: release notes for backstage-controller v0.9.0

### DIFF
--- a/docs/ske/50-releases/31-backstage-controller.mdx
+++ b/docs/ske/50-releases/31-backstage-controller.mdx
@@ -23,6 +23,12 @@ Please ensure that your Syntasso Registry secret is updated to reflect this. If 
 the image and the backstage-controller pod will fail to start.
 :::
 
+### [v0.9.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#backstage-controller/v0.9.0/) (2026-06-04)
+
+#### Security Fixes
+
+* Dependencies security updates
+
 ### [v0.8.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#backstage-controller/v0.8.0/) (2026-05-11)
 
 #### Security Fixes


### PR DESCRIPTION
Adds release notes for backstage-controller v0.9.0 (2026-06-04) — dependencies security updates.

**Do not merge until the release ships** — tracking release pipeline: https://github.com/syntasso/enterprise-kratix/actions