### PR TITLE
fix: set link to mcp release manifests as s3 bucket

### DIFF
--- a/docs/ske/50-releases/60-ske-mcp-server.mdx
+++ b/docs/ske/50-releases/60-ske-mcp-server.mdx
@@ -24,13 +24,13 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
-## [0.2.2](https://github.com/syntasso/ske-mcp-server/compare/ske-mcp-server-v0.2.1...ske-mcp-server-v0.2.2) (2026-06-04)
+## [0.2.2](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-mcp-server/v0.2.2/) (2026-06-04)
 
 ### Features
 
 * enable fast registration wth claude desktop ([641c849](https://github.com/syntasso/ske-mcp-server/commit/641c849ce1bde94a4f40c929c218edff79f55a0e))
 
-## [0.2.1](https://github.com/syntasso/ske-mcp-server/compare/ske-mcp-server-v0.2.0...ske-mcp-server-v0.2.1) (2026-06-02)
+## 0.2.1 (2026-06-02)
 
 ### Features
 


### PR DESCRIPTION
## Description
link for v0.2.2 was originally to private git repo and needed to be set to release bucket.
