### PR TITLE
docs: add ske-gui v0.16.0 and v0.17.0 release notes

### DIFF
--- a/docs/ske/50-releases/22-ske-gui.mdx
+++ b/docs/ske/50-releases/22-ske-gui.mdx
@@ -24,6 +24,21 @@ the image and the ske-gui pod will fail to start.
 
 ## Release Notes
 
+### [v0.17.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui/v0.17.0/) (2026-06-15)
+
+Released in Helm Chart version [v0.24.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui-helm-chart/0.24.0/)
+
+#### Chores
+
+* Dependencies security updates
+* Chainguard base image SHA updates
+
+### [v0.16.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui/v0.16.0/) (2026-06-10)
+
+#### Chores
+
+* Chainguard base image SHA updates
+
 ### [v0.15.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui/v0.15.0/) (2026-06-08)
 
 #### Security Fixes


### PR DESCRIPTION
## Summary

- Adds missing release notes for ske-gui v0.16.0 (2026-06-10) and v0.17.0 (2026-06-15)
- Both releases were shipped to the S3 bucket but the docs were never updated due to a cancelled CI run in helm-charts that broke the publish pipeline
- Helm chart 0.24.0 (appVersion v0.17.0) is being published separately via manual workflow dispatch