### PR TITLE
docs: add release notes for k8s-health-agent v0.10.0 and backstage-controller v0.10.0

### DIFF
--- a/docs/ske/50-releases/21-ske-health-agent.mdx
+++ b/docs/ske/50-releases/21-ske-health-agent.mdx
@@ -16,6 +16,14 @@ http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-heal
 
 ## Release Notes
 
+### [v0.10.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.10.0/) (2026-06-10)
+
+Released in Helm Chart version [0.24.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent-helm-chart/0.24.0/)
+
+#### Chores
+
+* Chainguard base image SHA updates
+
 ### [v0.9.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.9.0/) (2026-06-08)
 
 #### Security Fixes

--- a/docs/ske/50-releases/31-backstage-controller.mdx
+++ b/docs/ske/50-releases/31-backstage-controller.mdx
@@ -23,6 +23,12 @@ Please ensure that your Syntasso Registry secret is updated to reflect this. If 
 the image and the backstage-controller pod will fail to start.
 :::
 
+### [v0.10.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#backstage-controller/v0.10.0/) (2026-06-12)
+
+#### Chores
+
+* Chainguard base image SHA updates
+
 ### [v0.9.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#backstage-controller/v0.9.0/) (2026-06-04)
 
 #### Security Fixes


### PR DESCRIPTION
## Summary

- **k8s-health-agent v0.10.0** (2026-06-10) — Chainguard SHA updates; helm chart 0.24.0 already published
- **backstage-controller v0.10.0** (2026-06-12) — Chainguard SHA updates; delivered via ske-operator (helm chart deprecated at v0.4.2)

Split from #536 to unblock these two while ske-operator v0.29.0 docs wait on helm-charts cert-manager fix.

## Test plan
- [ ] Verify each new entry appears correctly in the rendered docs
- [ ] Confirm versions and dates match enterprise-kratix release tags