### PR TITLE
docs: add ske-tfstate-finder release notes

### DIFF
--- a/docs/ske/50-releases/30-pipeline-stages/20-tfstate-finder.mdx
+++ b/docs/ske/50-releases/30-pipeline-stages/20-tfstate-finder.mdx
@@ -27,6 +27,18 @@ will fail to pull the image within their Workflows
 
 ## Release Notes
 
+### [v0.13.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#aspects/ske-tfstate-finder/v0.13.0/) (2026-06-19)
+
+#### Bug Fixes
+
+* Bump `golang.org/x/net` to `v0.55.0` in `ske-tfstate-finder` to address `SNYK-GOLANG-GOLANGORGXNETIDNA-17116876`.
+
+### [v0.12.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#aspects/ske-tfstate-finder/v0.12.0/) (2026-05-29)
+
+#### Features
+
+* Updating Chainguard SHA in SKE images.
+
 ### [v0.11.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#aspects/ske-tfstate-finder/v0.11.0/) (2026-05-11)
 
 #### Security Fixes

--- a/docs/ske/50-releases/30-pipeline-stages/20-tfstate-finder.mdx
+++ b/docs/ske/50-releases/30-pipeline-stages/20-tfstate-finder.mdx
@@ -29,13 +29,13 @@ will fail to pull the image within their Workflows
 
 ### [v0.13.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#aspects/ske-tfstate-finder/v0.13.0/) (2026-06-19)
 
-#### Bug Fixes
+#### Security Fixes
 
-* Bump `golang.org/x/net` to `v0.55.0` in `ske-tfstate-finder` to address `SNYK-GOLANG-GOLANGORGXNETIDNA-17116876`.
+* Updated to include latest security updates.
 
 ### [v0.12.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#aspects/ske-tfstate-finder/v0.12.0/) (2026-05-29)
 
-#### Features
+#### Security Fixes
 
 * Updating Chainguard SHA in SKE images.
 


### PR DESCRIPTION
Add the missing ske-tfstate-finder release notes for v0.12.0 and v0.13.0 so the docs match the released image history.