### PR TITLE
docs: add ske-port-controller v0.3.0 release notes

### DIFF
--- a/docs/ske/50-releases/50-ske-port-controller.mdx
+++ b/docs/ske/50-releases/50-ske-port-controller.mdx
@@ -24,6 +24,15 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [ske-port-controller v0.3.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-port-controller/v0.3.0/) (2026-06-03)
+
+#### Security Fixes
+* Dependencies security updates
+
+#### Chores
+* Update Chainguard base image SHAs
+* Bump `github.com/containerd/containerd` dependency
+
 ### [ske-port-controller v0.2.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-port-controller/v0.2.0/) (2026-05-08)
 
 #### Fixes


### PR DESCRIPTION
## Summary
* Adds missing v0.3.0 release notes for ske-port-controller (released 2026-06-03)
* Security dep bump (`golang.org/x/net` v0.55.0) + Chainguard image SHA updates + containerd bump

## Test plan
- [ ] Verify rendered release notes page looks correct