### PR TITLE
docs: add SKE v0.50.0 release notes

### DIFF
--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,7 +19,7 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
-### [v0.50.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.50.0/) (2026-06-??)
+### [v0.50.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.50.0/) (2026-06-24)
 
 #### Maintenance
 

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,23 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [v0.50.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.50.0/) (2026-06-??)
+
+#### Features
+
+<!-- BLOCKED: the following features are shipped in v0.50.0 but docs branches have not landed.
+     feature/promise-upgrades and chore/docs-for-upgrades must merge before including these.
+
+* Retry previously failed Resource Requests in future UpgradeRuns.
+* UpgradeRun can now be suspended and resumed.
+* UpgradePlan supports `maxConcurrent` to control rollout concurrency.
+* UpgradePlan rollout groups support `resourceUpgradeWindows` (allow and deny windows) to restrict when upgrades may occur.
+-->
+
+#### Maintenance
+
+* Base image updates and package maintenance.
+
 ### [v0.49.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.49.0/) (2026-06-05)
 
 #### Fixes

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -21,17 +21,6 @@ Check the release notes below for information on each available version.
 
 ### [v0.50.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.50.0/) (2026-06-??)
 
-#### Features
-
-<!-- BLOCKED: the following features are shipped in v0.50.0 but docs branches have not landed.
-     feature/promise-upgrades and chore/docs-for-upgrades must merge before including these.
-
-* Retry previously failed Resource Requests in future UpgradeRuns.
-* UpgradeRun can now be suspended and resumed.
-* UpgradePlan supports `maxConcurrent` to control rollout concurrency.
-* UpgradePlan rollout groups support `resourceUpgradeWindows` (allow and deny windows) to restrict when upgrades may occur.
--->
-
 #### Maintenance
 
 * Base image updates and package maintenance.


### PR DESCRIPTION
## Summary

Adds release notes skeleton for SKE v0.50.0 (RC published 2026-06-16, 8-day soak).

Maintenance entry is complete. Features are blocked — see below.

## Blocked: UpgradeRun feature docs not yet published

v0.50.0 ships four UpgradeRun/UpgradePlan features that cannot be documented until their docs branches land:

| Feature | Commits |
|---|---|
| Retry previously failed RRs in future UpgradeRuns | `739efa4` |
| UpgradeRun suspend and resume | `6050a9c` |
| `maxConcurrent` in UpgradePlan | `5965bea` |
| Allow + deny upgrade windows (`resourceUpgradeWindows`) | `74ea92a` |

Docs branches: `feature/promise-upgrades`, `chore/docs-for-upgrades` — both exist, neither has an open PR.

**Action needed:** team to open PRs for those branches and merge before this PR can be completed. Features are stubbed as HTML comments in the file so nothing ships undocumented.

## Not included (already in component release notes)

* Kratix webhook timeout configurable — documented in ske-operator v0.28.0. Not duplicated per convention.

## Test plan
- [ ] Confirm release date and update `(2026-06-??)` when v0.50.0 full release is cut
- [ ] Uncomment and complete feature entries once `feature/promise-upgrades` / `chore/docs-for-upgrades` land