### PR TITLE
chore: fix typo

### DIFF
--- a/docs/ske/50-releases/60-ske-mcp-server.mdx
+++ b/docs/ske/50-releases/60-ske-mcp-server.mdx
@@ -28,7 +28,7 @@ Check the release notes below for information on each available version.
 
 ### Features
 
-* enable fast registration wth claude desktop ([641c849](https://github.com/syntasso/ske-mcp-server/commit/641c849ce1bde94a4f40c929c218edff79f55a0e))
+* enable fast registration with claude desktop ([641c849](https://github.com/syntasso/ske-mcp-server/commit/641c849ce1bde94a4f40c929c218edff79f55a0e))
 
 ## 0.2.1 (2026-06-02)
 


### PR DESCRIPTION
Small typo found in the release description.