### PR TITLE
chore: Add helm charts for missing releases

### DIFF
--- a/docs/ske/50-releases/20-ske-operator.mdx
+++ b/docs/ske/50-releases/20-ske-operator.mdx
@@ -26,6 +26,8 @@ To see which version of the helm chart corresponds to which version of the SKE-O
 
 ### [v0.29.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator/v0.29.0/) (2026-06-12)
 
+Released in Helm Chart version [version 0.75.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-operator-helm-chart/0.75.0/)
+
 #### Chores
 
 * Chainguard base image SHA updates

--- a/docs/ske/50-releases/22-ske-gui.mdx
+++ b/docs/ske/50-releases/22-ske-gui.mdx
@@ -41,17 +41,23 @@ Released in Helm Chart version [v0.24.0](http://syntasso-enterprise-releases.s3-
 
 ### [v0.15.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui/v0.15.0/) (2026-06-08)
 
+Released in Helm Chart version [v0.23.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui-helm-chart/0.23.0/)
+
 #### Security Fixes
 
 * Dependencies security updates
 
 ### [v0.14.1](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui/v0.14.1/) (2026-06-03)
 
+Released in Helm Chart version [v0.22.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui-helm-chart/0.22.0/)
+
 #### Security Fixes
 
 * Dependencies security updates
 
 ### [v0.14.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui/v0.14.0/) (2026-06-02)
+
+Released in Helm Chart version [v0.21.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-gui-helm-chart/0.21.0/)
 
 #### Security Fixes
 


### PR DESCRIPTION
26/27 of ske-operator has no charts for those releases... dont know why.

## Description
This relates to issue #


## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
