### PR TITLE
feat: document waits for delete workflows

### DIFF
--- a/docs/main/03-reference/11-promises/08-workflows.md
+++ b/docs/main/03-reference/11-promises/08-workflows.md
@@ -222,10 +222,11 @@ Works based on an external condition. Removing the `kratix.io/workflow-suspended
 re-runs the Delete Pipeline; if it completes without suspending again, the Works are
 deleted and the Promise deletion completes.
 
-A Delete Pipeline can also write its own `/kratix/metadata/status.yaml`, the same way a
-Configure Pipeline does. Writing a `message` key there surfaces that message via
-`kubectl get`, rather than only via `kubectl describe`. See the
-[status documentation](/main/reference/resources/status) for more detail.
+When Delete Pipeline is suspended, it can also write its own
+`/kratix/metadata/status.yaml`, the same way a Configure Pipeline does. Writing a
+`message` key there surfaces that message via `kubectl get`, rather than only via
+`kubectl describe`. See the [status documentation](/main/reference/resources/status)
+for more detail.
 
 The example below shows how a `promise.delete` workflow can be defined.
 

--- a/docs/main/03-reference/11-promises/08-workflows.md
+++ b/docs/main/03-reference/11-promises/08-workflows.md
@@ -209,6 +209,24 @@ workflow.
 This Pipeline is responsible for cleaning up resources and configurations that were set up
 by the `promise.configure` workflow.
 
+### Suspending or Retrying a Delete workflow
+
+Like the Configure workflow, a Delete Pipeline can write
+[`/kratix/metadata/workflow-control.yaml`](../workflows#workflow-control)
+to suspend or retry itself before it finishes.
+
+While a Delete Pipeline is suspended, Kratix does not delete the Works created by the
+Promise, and the `DeleteWorkflowCompleted` condition is set to `False` with reason
+`DeleteWorkflowSuspended`. This lets a Delete Pipeline gate teardown of the Promise's
+Works based on an external condition. Removing the `kratix.io/workflow-suspended` label
+re-runs the Delete Pipeline; if it completes without suspending again, the Works are
+deleted and the Promise deletion completes.
+
+A Delete Pipeline can also write its own `/kratix/metadata/status.yaml`, the same way a
+Configure Pipeline does. Writing a `message` key there surfaces that message via
+`kubectl get`, rather than only via `kubectl describe`. See the
+[status documentation](/main/reference/resources/status) for more detail.
+
 The example below shows how a `promise.delete` workflow can be defined.
 
 ```yaml

--- a/docs/main/03-reference/11-promises/09-status-events.mdx
+++ b/docs/main/03-reference/11-promises/09-status-events.mdx
@@ -19,6 +19,11 @@ A Promise exposes the following list of conditions:
 - `WorksSucceeded` – all Works created for the Promise has completed.
 - `Available` – Promise is ready to accept Resource requests.
 - `Reconciled` – Promise has been successfully reconciled; set to true when all the above conditions are all true.
+- `DeleteWorkflowCompleted` – only present while a Promise is being deleted and the Delete
+  workflow has not finished. Its `reason` is `DeleteWorkflowFailed` if the Delete Pipeline
+  failed, or `DeleteWorkflowSuspended` if the Delete Pipeline suspended itself via the
+  [workflow-control file](/main/reference/promises/workflows#suspending-a-workflow). This
+  condition is not present once deletion completes, since the Promise itself is removed.
 
 Example Promise conditions from `kubectl get promise <name> -o yaml`:
 

--- a/docs/main/03-reference/11-promises/10-reconciliation-labels.md
+++ b/docs/main/03-reference/11-promises/10-reconciliation-labels.md
@@ -36,6 +36,13 @@ While the label is present:
 
 If the label is removed, Kratix resumes from the suspended Pipeline.
 
+:::note
+The same labels work with Configure and Delete Pipelines. During Delete
+Pipelines, Works created by the Promise are **not deleted**, and the
+`DeleteWorkflowCompleted` condition is set to `False` with reason
+`DeleteWorkflowSuspended`. Removing the label re-runs the Delete Pipeline.
+:::
+
 ## Pausing Reconciliation
 
 ```yaml

--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -193,7 +193,7 @@ When a Pipeline writes `suspend: true`, Kratix:
 - stores the optional message on that pipeline entry
 - stops executing later Pipelines in the workflow
 
-:::info
+#### Configure Workflow specifics
 
 Suspending a Pipeline will not stop the execution of later stages in the same Pipeline. If you want to guarantee that no other stage is executed, you can either:
 
@@ -201,9 +201,22 @@ Suspending a Pipeline will not stop the execution of later stages in the same Pi
 1. Have the suspend stage as the only stage in the Pipeline.
 1. Ensure that every stage checks for the workflow-control file.
 
-:::
 
-If `kratix.io/workflow-suspended` is removed, Kratix starts from the suspended
+#### Delete Workflow specifics
+
+While a Delete Pipeline can also write `suspend: true`, because it has only
+a single Pipeline the "starting from the suspended Pipeline" means Kratix
+re-runs that same Pipeline.
+
+While a Delete Pipeline is suspended, the Works it would otherwise clean up
+are **not deleted** — the Promise or Resource request stays in a 
+`DeleteWorkflowSuspended` state until the label is removed and the Pipeline
+completes without suspending again.
+
+
+#### Resuming a suspended pipeline
+
+When `kratix.io/workflow-suspended` is removed, Kratix starts from the suspended
 Pipeline.
 
 When a Pipeline writes `retryAfter`, Kratix will treat the current pipeline as
@@ -500,16 +513,21 @@ Files written to `/kratix/output` in `delete` Pipelines will be ignored.
 
 ### Metadata
 
-All containers in a `configure` Pipeline have access a shared **metadata directory**
-mounted at `/kratix/metadata`.
+All containers in a Pipeline, whether `configure` or `delete`, have access to a shared
+**metadata directory** mounted at `/kratix/metadata`.
 
 Pipeline containers can control aspects of how Kratix behaves by creating special files in
 this directory:
 
-- `destination-selectors.yaml` can be added to any Promise to further refine where the
-  resources in `/kratix/output` will be [scheduled](./destinations/multidestination-management).
+- `destination-selectors.yaml` can be added to any `configure` Pipeline to further refine
+  where the resources in `/kratix/output` will be
+  [scheduled](./destinations/multidestination-management). Since `/kratix/output` is
+  ignored in `delete` Pipelines, this file has no effect there.
 - `status.yaml` allows the Pipeline to communicate information about the resource back to
   the requester. See the [status documentation for more information](./resources/status).
+- `workflow-control.yaml` lets the Pipeline suspend or retry itself; see
+  [Workflow Control](#workflow-control) above. This applies to both `configure` and
+  `delete` Pipelines.
 
 #### Passing data between containers
 

--- a/docs/main/03-reference/15-resources/02-workflows.md
+++ b/docs/main/03-reference/15-resources/02-workflows.md
@@ -211,10 +211,12 @@ Resource's Works based on an external condition. Removing the `kratix.io/workflo
 label re-runs the Delete Pipeline; if it completes without suspending again, the Works
 are deleted and the Resource deletion completes.
 
-A Delete Pipeline can also write its own `/kratix/metadata/status.yaml`, the same way a
-Configure Pipeline does. Writing a `message` key there surfaces that message via
-`kubectl get`, rather than only via `kubectl describe`. See the
-[status documentation](/main/reference/resources/status) for more detail.
+On a typical Delete Pipeline the resource is removed before a status can be written.
+But when leveraging the suspend functionality the Delete Pipeline can also write its own
+`/kratix/metadata/status.yaml`, the same way a Configure Pipeline does. Writing a
+`message` key there surfaces that message via `kubectl get`, rather than only via
+`kubectl describe`. See the [status documentation](/main/reference/resources/status)
+for more detail.
 
 The example below shows how a `resource.delete` workflow can be defined.
 

--- a/docs/main/03-reference/15-resources/02-workflows.md
+++ b/docs/main/03-reference/15-resources/02-workflows.md
@@ -109,7 +109,7 @@ To re-run a workflow following a Pipeline failure, you can perform a
 [manual reconciliation](/main/reference/resources/reconciliation-labels#manual-reconciliation) of the Resource, which will trigger the
 workflow again from the beginning.
 
-### Suspending or Retrying a workflow
+### Suspending or Retrying a workflow {#suspending-a-workflow}
 
 A Resource Configure Pipeline can output an optional file to suspend its execution:
 
@@ -197,6 +197,24 @@ Pipeline is running.
 
 This Pipeline is responsible for cleaning up resources and configurations that were set up
 by the `resource.configure` workflow.
+
+### Suspending or Retrying a Delete workflow
+
+Like the Configure workflow, a Delete Pipeline can write
+[`/kratix/metadata/workflow-control.yaml`](../workflows#workflow-control)
+to suspend or retry itself before it finishes.
+
+While a Delete Pipeline is suspended, Kratix does not delete the Works created by the
+Resource request, and the `DeleteWorkflowCompleted` condition is set to `False` with
+reason `DeleteWorkflowSuspended`. This lets a Delete Pipeline gate teardown of the
+Resource's Works based on an external condition. Removing the `kratix.io/workflow-suspended`
+label re-runs the Delete Pipeline; if it completes without suspending again, the Works
+are deleted and the Resource deletion completes.
+
+A Delete Pipeline can also write its own `/kratix/metadata/status.yaml`, the same way a
+Configure Pipeline does. Writing a `message` key there surfaces that message via
+`kubectl get`, rather than only via `kubectl describe`. See the
+[status documentation](/main/reference/resources/status) for more detail.
 
 The example below shows how a `resource.delete` workflow can be defined.
 

--- a/docs/main/03-reference/15-resources/04-status.md
+++ b/docs/main/03-reference/15-resources/04-status.md
@@ -13,7 +13,22 @@ Resource back to the resource requester by writing information to
 `/kratix/metadata/status.yaml`. The file can contain arbitrary key values, with the
 `message` key being a special key that is communicated back to the user when
 running `kubectl get <resource-request>`. For example if the Pipeline container wrote the
-following to the `/kratix/metadata/status.yaml` file:
+As part of a Configure Pipeline you can optionally send information about the
+Resource back to the resource requester by writing information to
+`/kratix/metadata/status.yaml`.
+
+:::info
+
+Status is also available in Delete Pipelines, but only if you are using the suspend
+functionality. On an immediate delete the resource will not update status as the
+resource will be removed before status would be written.
+
+:::
+
+The file can contain arbitrary key values, with the `message` key being a special
+key that is communicated back to the user when running `kubectl get
+<resource-request>`. For example if the Pipeline container wrote the following to
+the `/kratix/metadata/status.yaml` file:
 
 ```yaml
 message: Resource provisioned with database size 10Gb

--- a/docs/main/03-reference/15-resources/04-status.md
+++ b/docs/main/03-reference/15-resources/04-status.md
@@ -8,8 +8,8 @@ import StatusUpdateFlowDiagram from "/img/docs/workshop/part-ii-status-update-fl
 
 # Status
 
-As part of a Configure Pipeline you can optionally send information about the Resource
-back to the resource requester by writing information to
+As part of a Configure or Delete Pipeline you can optionally send information about the
+Resource back to the resource requester by writing information to
 `/kratix/metadata/status.yaml`. The file can contain arbitrary key values, with the
 `message` key being a special key that is communicated back to the user when
 running `kubectl get <resource-request>`. For example if the Pipeline container wrote the
@@ -69,6 +69,12 @@ Resource and output these to the `status.yaml` again.
 Status can also be used as a method of communicating information back to the
 Delete workflow, such as the name of any external resources imperatively
 created in the pipeline that need to be deleted as part of the cleanup.
+
+The Delete Pipeline can also write its own `/kratix/metadata/status.yaml` directly,
+the same way a Configure Pipeline does. This is particularly useful together with
+[suspending a Delete Pipeline](workflows#suspending-or-retrying-a-delete-workflow): writing a
+`message` key to `status.yaml` surfaces that message via `kubectl get`, rather than
+only via `kubectl describe`.
 
 ## Multiple Pipelines
 

--- a/docs/main/03-reference/15-resources/06-status-events.mdx
+++ b/docs/main/03-reference/15-resources/06-status-events.mdx
@@ -17,6 +17,11 @@ Resources have the following list of conditions:
 - `ConfigureWorkflowCompleted` – all Configure workflow pipelines finished successfully.
 - `WorksSucceeded` – every Work created for the Resource has completed.
 - `Reconciled` – Resource has been successfully reconciled; set to true when all the above conditions are all true.
+- `DeleteWorkflowCompleted` – only present while a Resource is being deleted and the Delete
+  workflow has not finished. Its `reason` is `DeleteWorkflowFailed` if the Delete Pipeline
+  failed, or `DeleteWorkflowSuspended` if the Delete Pipeline suspended itself via the
+  [workflow-control file](/main/reference/promises/workflows#suspending-a-workflow). This
+  condition is not present once deletion completes, since the Resource itself is removed.
 
 Example output:
 

--- a/docs/main/03-reference/15-resources/07-reconciliation-labels.md
+++ b/docs/main/03-reference/15-resources/07-reconciliation-labels.md
@@ -47,7 +47,7 @@ Promises can signal Kratix that the current resource workflow should be suspende
 kratix.io/workflow-suspended: "true"
 ```
 
-This label marks a Resource configure workflow as suspended.
+This label marks a Resource Configure or Delete workflow as suspended.
 
 While the label is present:
 
@@ -55,6 +55,13 @@ While the label is present:
 - the current pipeline is marked as `Suspended` in `status.kratix.workflows.pipelines`
 
 If the label is removed, Kratix resumes from the suspended Pipeline.
+
+:::note
+The same labels work with Configure and Delete Pipelines. During Delete
+Pipelines, Works created by the Promise are **not deleted**, and the
+`DeleteWorkflowCompleted` condition is set to `False` with reason
+`DeleteWorkflowSuspended`. Removing the label re-runs the Delete Pipeline.
+:::
 
 ## Pausing Reconciliation
 

--- a/docs/main/04-guides/11-gating-deletion-with-workflow-control.mdx
+++ b/docs/main/04-guides/11-gating-deletion-with-workflow-control.mdx
@@ -1,0 +1,233 @@
+---
+title: Gating Deletion with Workflow Control
+description: Suspend a Delete Pipeline to hold a Resource's underlying infrastructure in place until an external condition is met.
+---
+
+```mdx-code-block
+import PartialGuidesPreRequisites from '@site/docs/_partials/_generic_prereqs_guides.md';
+```
+
+Delete Pipelines can suspend themselves the same way Configure Pipelines can, using the
+[Workflow Control file](/main/reference/workflows#workflow-control). This lets a Promise
+require an external condition — an approval, a backup, a check against another system —
+before the underlying Works, and the infrastructure they represent, are actually torn down.
+
+**In this guide, you will:**
+* Write a Resource Delete Pipeline that checks for an approval before continuing
+* Delete a Resource request and observe Kratix hold its Works in place while the Delete
+  Pipeline is suspended
+* Approve the deletion and watch Kratix resume the Delete Pipeline and remove the Works
+
+<PartialGuidesPreRequisites />
+
+## The scenario
+
+A platform team offers a `database` Promise. Deleting a `database` destroys real data, so
+the team wants a human to confirm the deletion before Kratix removes the underlying Work.
+The Delete Pipeline checks for a `ConfigMap` that represents that confirmation; if it is
+missing, the Pipeline suspends itself instead of completing.
+
+## 1. Define the Promise
+
+Create `database-promise.yaml`:
+
+```yaml title="database-promise.yaml"
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  name: database
+spec:
+  api:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: databases.example.promise.syntasso.io
+    spec:
+      group: example.promise.syntasso.io
+      names:
+        kind: database
+        plural: databases
+        singular: database
+      scope: Namespaced
+      versions:
+        - name: v1alpha1
+          served: true
+          storage: true
+          schema:
+            openAPIV3Schema:
+              type: object
+              properties:
+                spec:
+                  type: object
+                  properties:
+                    size:
+                      type: string
+  workflows:
+    resource:
+      configure:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: configure-pipeline
+          spec:
+            containers:
+              - name: configure
+                image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+                command: ["/bin/sh", "-c"]
+                args:
+                  - |
+                    set -eu
+                    cat <<EOF > /kratix/output/configmap.yaml
+                    apiVersion: v1
+                    kind: ConfigMap
+                    metadata:
+                      name: ${KRATIX_OBJECT_NAME}-generated
+                      namespace: default
+                    data:
+                      status: provisioned
+                    EOF
+      delete:
+        - apiVersion: platform.kratix.io/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: delete-pipeline
+          spec:
+            rbac:
+              permissions:
+                - apiGroups: [""]
+                  resources: ["configmaps"]
+                  verbs: ["get"]
+            containers:
+              - name: check-deletion-approved
+                image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+                command: ["/bin/sh", "-c"]
+                args:
+                  - |
+                    set -eu
+                    if kubectl get configmap "${KRATIX_OBJECT_NAME}-delete-approved" -n default >/dev/null 2>&1; then
+                      echo "deletion approved; proceeding"
+                    else
+                      echo "deletion not yet approved; suspending"
+                      cat <<EOF > /kratix/metadata/workflow-control.yaml
+                    suspend: true
+                    message: "waiting for deletion approval"
+                    EOF
+                    fi
+```
+
+The Delete Pipeline has a single container, `check-deletion-approved`, that looks for a
+`ConfigMap` named `<resource-name>-delete-approved`. If it is not found, the container
+writes `suspend: true` to `/kratix/metadata/workflow-control.yaml` instead of failing.
+
+Apply the Promise:
+
+```bash
+kubectl --context $PLATFORM apply --filename database-promise.yaml
+```
+
+## 2. Request a database
+
+Create `database-example.yaml`:
+
+```yaml title="database-example.yaml"
+apiVersion: example.promise.syntasso.io/v1alpha1
+kind: database
+metadata:
+  name: example
+spec:
+  size: small
+```
+
+```bash
+kubectl --context $PLATFORM apply --filename database-example.yaml
+```
+
+Wait for the Configure workflow to finish:
+
+```bash
+kubectl --context $PLATFORM wait database/example --for=condition=ConfigureWorkflowCompleted --timeout=60s
+```
+
+## 3. Delete the database and observe the suspension
+
+```bash
+kubectl --context $PLATFORM delete database example --wait=false
+```
+
+The Delete Pipeline runs, finds no approval `ConfigMap`, and suspends. Check the status:
+
+```bash
+kubectl --context $PLATFORM get database example -o yaml
+```
+
+The relevant parts of the output (other status fields are omitted below for brevity):
+
+```yaml
+status:
+  conditions:
+    # ...
+    - message: Delete pipeline is waiting before deleting Works
+      reason: DeleteWorkflowSuspended
+      status: "False"
+      type: DeleteWorkflowCompleted
+  kratix:
+    workflows:
+      pipelines:
+        - name: delete-pipeline
+          phase: Suspended
+          message: waiting for deletion approval
+```
+
+```bash
+kubectl --context $PLATFORM get database example -o jsonpath='{.metadata.labels}'
+```
+
+```json
+{"kratix.io/promise-name":"database","kratix.io/workflow-suspended":"true"}
+```
+
+While that label is present, Kratix does not delete the Works created for `example` — the
+underlying infrastructure stays exactly as it was. You can confirm this by listing the Works
+for the Resource; the count stays unchanged for as long as the label is present:
+
+```bash
+kubectl --context $PLATFORM get works -n default -l kratix.io/promise-name=database,kratix.io/resource-name=example
+```
+
+```
+NAME                                         STATUS
+database-example-configure-pipeline-c9180    Ready
+```
+
+## 4. Approve and resume the deletion
+
+Create the approval `ConfigMap` and remove the suspend label:
+
+```bash
+kubectl --context $PLATFORM create configmap example-delete-approved --namespace default
+kubectl --context $PLATFORM label database example kratix.io/workflow-suspended-
+```
+
+Removing the label re-runs the Delete Pipeline. This time it finds the approval `ConfigMap`
+and completes normally, so Kratix deletes the Works and finishes removing `example`:
+
+```bash
+kubectl --context $PLATFORM get database example
+```
+
+```
+Error from server (NotFound): databases.example.promise.syntasso.io "example" not found
+```
+
+## Promise Delete workflows
+
+A Promise's own Delete Pipeline (defined under `spec.workflows.promise.delete`) can suspend
+itself in exactly the same way. While suspended, the Works created by the Promise are held
+in place, and the Promise's `DeleteWorkflowCompleted` condition reports
+`DeleteWorkflowSuspended` — the same mechanism demonstrated above for Resource requests.
+
+## See also
+
+* [Workflow Control reference](/main/reference/workflows#workflow-control)
+* [Resource Reconciliation Labels](/main/reference/resources/reconciliation-labels#unsuspend-a-workflow)
+* [Promise Reconciliation Labels](/main/reference/promises/reconciliation-labels#unsuspending-a-workflow)


### PR DESCRIPTION
## Description
Kratix is extending workflow-control suspend/retry to Delete
Pipelines (previously Configure-only), and a Delete Pipeline can now
write status.yaml directly. Several reference pages stated or implied
this only applied to Configure workflows, and DeleteWorkflowCompleted
wasn't documented at all, so users hitting a suspended deletion had
nowhere to look.

Supports syntasso/kratix#834.


## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
