### PR TITLE
docs: SKE Platform Manager release notes and installation docs

### DIFF
--- a/docs/ske/01-installing-ske/02-advanced-install.mdx
+++ b/docs/ske/01-installing-ske/02-advanced-install.mdx
@@ -22,8 +22,8 @@ Resource](/ske/reference/ske-operator#kratix-crd).
 
 To install the SKE Operator and instantiate a new SKE instance, we provide several mechanisms:
 
-* [With the SKE Operator Helm Chart](#via-helm-chart), you can deploy the Operator and SKE with all the customisations you need, including air-gapped environments.
-* [With the SKE Operator manifest and the Kratix CRD](#via-manifests), you have direct access to the files being deployed, and can customise it manually.
+- [With the SKE Operator Helm Chart](#via-helm-chart), you can deploy the Operator and SKE with all the customisations you need, including air-gapped environments.
+- [With the SKE Operator manifest and the Kratix CRD](#via-manifests), you have direct access to the files being deployed, and can customise it manually.
 
 The sections below cover each one of these methods of installation.
 
@@ -58,7 +58,6 @@ You can see all available configuration in the
 
 :::
 
-
 <details>
   <summary>Suggested starter `values.yaml` file</summary>
 
@@ -75,34 +74,34 @@ You can see all available configuration in the
 <details>
   <summary>Example air-gapped `values.yaml` file</summary>
 
-  To use this example, please set all values to your specific environment
+To use this example, please set all values to your specific environment
 
-  ```yaml
-    skeLicense: your-token-here
-    skeDeployment:
-      version: latest
-    imageRegistry:
-      host: "ghcr.io"
-      managePullSecret: false
-      imagePullSecret: "my-secret"
-      skeOperatorImage:
-        name: "syntasso/ske-operator"
-      skePlatformImage:
-        name: "syntasso/ske-platform"
-    releaseStorage:
-      path: "ske"
-      git:
-        branch: main
-        repo: https://github.com/org/repo
-        secret:
-          name: git-creds # must be in the same namespace as the operator; must contain keys: username, password
-          values: # optional: provide username/password here and the chart creates the Secret for you;
-                  # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
-            username: "my-username"
-            password: "my-password"
-    ```
+```yaml
+  skeLicense: your-token-here
+  skeDeployment:
+    version: latest
+  imageRegistry:
+    host: "ghcr.io"
+    managePullSecret: false
+    imagePullSecret: "my-secret"
+    skeOperatorImage:
+      name: "syntasso/ske-operator"
+    skePlatformImage:
+      name: "syntasso/ske-platform"
+  releaseStorage:
+    path: "ske"
+    git:
+      branch: main
+      repo: https://github.com/org/repo
+      secret:
+        name: git-creds # must be in the same namespace as the operator; must contain keys: username, password
+        values: # optional: provide username/password here and the chart creates the Secret for you;
+                # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
+          username: "my-username"
+          password: "my-password"
+  ```
 
-    NOTE: Token refers to the [Syntasso registry token](../reference/tokens#syntasso-registry-token)
+  NOTE: Token refers to the [Syntasso registry token](../reference/tokens#syntasso-registry-token)
 
 </details>
 
@@ -297,38 +296,26 @@ imageRegistry:
 
 <Tabs className="boxedTabs" groupId="stateStore">
   <TabItem value="bucket" label="Mirroring from Bucket">
-  ```yaml
-  releaseStorage:
-    path: "ske" # the path within the bucket that contains the SKE Versions
-    bucket:
-      name: "syntasso-enterprise-releases"
-      region: "eu-west-2"
-        secret:
-          name: "my-secret" # must be in the same namespace as the operator; must contain keys: accessKeyID, secretAccessKey
-          values: # optional: provide accessKeyID/secretAccessKey here and the chart creates the Secret for you;
-                  # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
-            accessKeyID: "my-access"
-            secretAccessKey: "my-secret"
-  ```
+    ```yaml releaseStorage: path: "ske" # the path within the bucket that
+    contains the SKE Versions bucket: name: "syntasso-enterprise-releases"
+    region: "eu-west-2" secret: name: "my-secret" # must be in the same
+    namespace as the operator; must contain keys: accessKeyID, secretAccessKey
+    values: # optional: provide accessKeyID/secretAccessKey here and the chart
+    creates the Secret for you; # omit values and pre-create the Secret yourself
+    to avoid storing credentials in Helm values accessKeyID: "my-access"
+    secretAccessKey: "my-secret" ```
   </TabItem>
   <TabItem value="git" label="Mirroring from Git Repo">
-  ```yaml
-  releaseStorage:
-    path: "ske" # the path within the Git Repo that contains the SKE Versions
-    git:
-      branch: main
-      repo: https://github.com/org/repo
-      secret:
-        name: git-creds # must be in the same namespace as the operator; must contain keys: username, password
-        values: # optional: provide username/password here and the chart creates the Secret for you;
-                # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
-          username: "my-username"
-          password: "my-password"
-  ```
+    ```yaml releaseStorage: path: "ske" # the path within the Git Repo that
+    contains the SKE Versions git: branch: main repo:
+    https://github.com/org/repo secret: name: git-creds # must be in the same
+    namespace as the operator; must contain keys: username, password values: #
+    optional: provide username/password here and the chart creates the Secret
+    for you; # omit values and pre-create the Secret yourself to avoid storing
+    credentials in Helm values username: "my-username" password: "my-password"
+    ```
   </TabItem>
 </Tabs>
-
-
 
 ### Install the Operator
 
@@ -350,11 +337,25 @@ To verify that Syntasso Kratix Enterprise has been installed successfully, run t
 kubectl get deployments.apps --namespace kratix-platform-system
 ```
 
-You should see the following output:
+You should see the SKE Operator and the Kratix Platform Controller:
+
+| Deployment                           | Description                                                            |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| `ske-operator-controller-manager`    | The SKE Operator, which manages the lifecycle of your SKE installation |
+| `kratix-platform-controller-manager` | The Kratix Platform Controller — the core SKE control plane            |
 
 ```shell-session
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 kratix-platform-controller-manager   1/1     1            1           1h
+ske-operator-controller-manager      1/1     1            1           1h
+```
+
+For SKE versions that include the Platform Manager, you will also see a `ske-platform-manager` deployment, which manages SKE upgrade plans and runs:
+
+```shell-session
+NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
+kratix-platform-controller-manager   1/1     1            1           1h
+ske-platform-manager                 1/1     1            1           1h
 ske-operator-controller-manager      1/1     1            1           1h
 ```
 
@@ -467,11 +468,25 @@ To verify that Syntasso Kratix Enterprise has been installed successfully, run t
 kubectl get deployments.apps --namespace kratix-platform-system
 ```
 
-You should see the following output:
+You should see the SKE Operator and the Kratix Platform Controller:
+
+| Deployment                           | Description                                                            |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| `ske-operator-controller-manager`    | The SKE Operator, which manages the lifecycle of your SKE installation |
+| `kratix-platform-controller-manager` | The Kratix Platform Controller — the core SKE control plane            |
 
 ```shell-session
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 kratix-platform-controller-manager   1/1     1            1           1h
+ske-operator-controller-manager      1/1     1            1           1h
+```
+
+For SKE versions that include the Platform Manager, you will also see a `ske-platform-manager` deployment, which manages SKE upgrade plans and runs:
+
+```shell-session
+NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
+kratix-platform-controller-manager   1/1     1            1           1h
+ske-platform-manager                 1/1     1            1           1h
 ske-operator-controller-manager      1/1     1            1           1h
 ```
 

--- a/docs/ske/01-installing-ske/02-advanced-install.mdx
+++ b/docs/ske/01-installing-ske/02-advanced-install.mdx
@@ -22,8 +22,8 @@ Resource](/ske/reference/ske-operator#kratix-crd).
 
 To install the SKE Operator and instantiate a new SKE instance, we provide several mechanisms:
 
-- [With the SKE Operator Helm Chart](#via-helm-chart), you can deploy the Operator and SKE with all the customisations you need, including air-gapped environments.
-- [With the SKE Operator manifest and the Kratix CRD](#via-manifests), you have direct access to the files being deployed, and can customise it manually.
+* [With the SKE Operator Helm Chart](#via-helm-chart), you can deploy the Operator and SKE with all the customisations you need, including air-gapped environments.
+* [With the SKE Operator manifest and the Kratix CRD](#via-manifests), you have direct access to the files being deployed, and can customise it manually.
 
 The sections below cover each one of these methods of installation.
 
@@ -58,6 +58,7 @@ You can see all available configuration in the
 
 :::
 
+
 <details>
   <summary>Suggested starter `values.yaml` file</summary>
 
@@ -74,34 +75,34 @@ You can see all available configuration in the
 <details>
   <summary>Example air-gapped `values.yaml` file</summary>
 
-To use this example, please set all values to your specific environment
+  To use this example, please set all values to your specific environment
 
-```yaml
-  skeLicense: your-token-here
-  skeDeployment:
-    version: latest
-  imageRegistry:
-    host: "ghcr.io"
-    managePullSecret: false
-    imagePullSecret: "my-secret"
-    skeOperatorImage:
-      name: "syntasso/ske-operator"
-    skePlatformImage:
-      name: "syntasso/ske-platform"
-  releaseStorage:
-    path: "ske"
-    git:
-      branch: main
-      repo: https://github.com/org/repo
-      secret:
-        name: git-creds # must be in the same namespace as the operator; must contain keys: username, password
-        values: # optional: provide username/password here and the chart creates the Secret for you;
-                # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
-          username: "my-username"
-          password: "my-password"
-  ```
+  ```yaml
+    skeLicense: your-token-here
+    skeDeployment:
+      version: latest
+    imageRegistry:
+      host: "ghcr.io"
+      managePullSecret: false
+      imagePullSecret: "my-secret"
+      skeOperatorImage:
+        name: "syntasso/ske-operator"
+      skePlatformImage:
+        name: "syntasso/ske-platform"
+    releaseStorage:
+      path: "ske"
+      git:
+        branch: main
+        repo: https://github.com/org/repo
+        secret:
+          name: git-creds # must be in the same namespace as the operator; must contain keys: username, password
+          values: # optional: provide username/password here and the chart creates the Secret for you;
+                  # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
+            username: "my-username"
+            password: "my-password"
+    ```
 
-  NOTE: Token refers to the [Syntasso registry token](../reference/tokens#syntasso-registry-token)
+    NOTE: Token refers to the [Syntasso registry token](../reference/tokens#syntasso-registry-token)
 
 </details>
 
@@ -296,26 +297,38 @@ imageRegistry:
 
 <Tabs className="boxedTabs" groupId="stateStore">
   <TabItem value="bucket" label="Mirroring from Bucket">
-    ```yaml releaseStorage: path: "ske" # the path within the bucket that
-    contains the SKE Versions bucket: name: "syntasso-enterprise-releases"
-    region: "eu-west-2" secret: name: "my-secret" # must be in the same
-    namespace as the operator; must contain keys: accessKeyID, secretAccessKey
-    values: # optional: provide accessKeyID/secretAccessKey here and the chart
-    creates the Secret for you; # omit values and pre-create the Secret yourself
-    to avoid storing credentials in Helm values accessKeyID: "my-access"
-    secretAccessKey: "my-secret" ```
+  ```yaml
+  releaseStorage:
+    path: "ske" # the path within the bucket that contains the SKE Versions
+    bucket:
+      name: "syntasso-enterprise-releases"
+      region: "eu-west-2"
+        secret:
+          name: "my-secret" # must be in the same namespace as the operator; must contain keys: accessKeyID, secretAccessKey
+          values: # optional: provide accessKeyID/secretAccessKey here and the chart creates the Secret for you;
+                  # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
+            accessKeyID: "my-access"
+            secretAccessKey: "my-secret"
+  ```
   </TabItem>
   <TabItem value="git" label="Mirroring from Git Repo">
-    ```yaml releaseStorage: path: "ske" # the path within the Git Repo that
-    contains the SKE Versions git: branch: main repo:
-    https://github.com/org/repo secret: name: git-creds # must be in the same
-    namespace as the operator; must contain keys: username, password values: #
-    optional: provide username/password here and the chart creates the Secret
-    for you; # omit values and pre-create the Secret yourself to avoid storing
-    credentials in Helm values username: "my-username" password: "my-password"
-    ```
+  ```yaml
+  releaseStorage:
+    path: "ske" # the path within the Git Repo that contains the SKE Versions
+    git:
+      branch: main
+      repo: https://github.com/org/repo
+      secret:
+        name: git-creds # must be in the same namespace as the operator; must contain keys: username, password
+        values: # optional: provide username/password here and the chart creates the Secret for you;
+                # omit values and pre-create the Secret yourself to avoid storing credentials in Helm values
+          username: "my-username"
+          password: "my-password"
+  ```
   </TabItem>
 </Tabs>
+
+
 
 ### Install the Operator
 
@@ -337,25 +350,11 @@ To verify that Syntasso Kratix Enterprise has been installed successfully, run t
 kubectl get deployments.apps --namespace kratix-platform-system
 ```
 
-You should see the SKE Operator and the Kratix Platform Controller:
-
-| Deployment                           | Description                                                            |
-| ------------------------------------ | ---------------------------------------------------------------------- |
-| `ske-operator-controller-manager`    | The SKE Operator, which manages the lifecycle of your SKE installation |
-| `kratix-platform-controller-manager` | The Kratix Platform Controller — the core SKE control plane            |
+You should see the following output:
 
 ```shell-session
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 kratix-platform-controller-manager   1/1     1            1           1h
-ske-operator-controller-manager      1/1     1            1           1h
-```
-
-For SKE versions that include the Platform Manager, you will also see a `ske-platform-manager` deployment, which manages SKE upgrade plans and runs:
-
-```shell-session
-NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
-kratix-platform-controller-manager   1/1     1            1           1h
-ske-platform-manager                 1/1     1            1           1h
 ske-operator-controller-manager      1/1     1            1           1h
 ```
 
@@ -468,25 +467,11 @@ To verify that Syntasso Kratix Enterprise has been installed successfully, run t
 kubectl get deployments.apps --namespace kratix-platform-system
 ```
 
-You should see the SKE Operator and the Kratix Platform Controller:
-
-| Deployment                           | Description                                                            |
-| ------------------------------------ | ---------------------------------------------------------------------- |
-| `ske-operator-controller-manager`    | The SKE Operator, which manages the lifecycle of your SKE installation |
-| `kratix-platform-controller-manager` | The Kratix Platform Controller — the core SKE control plane            |
+You should see the following output:
 
 ```shell-session
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 kratix-platform-controller-manager   1/1     1            1           1h
-ske-operator-controller-manager      1/1     1            1           1h
-```
-
-For SKE versions that include the Platform Manager, you will also see a `ske-platform-manager` deployment, which manages SKE upgrade plans and runs:
-
-```shell-session
-NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
-kratix-platform-controller-manager   1/1     1            1           1h
-ske-platform-manager                 1/1     1            1           1h
 ske-operator-controller-manager      1/1     1            1           1h
 ```
 

--- a/docs/ske/01-installing-ske/02-advanced-install.mdx
+++ b/docs/ske/01-installing-ske/02-advanced-install.mdx
@@ -358,6 +358,12 @@ kratix-platform-controller-manager   1/1     1            1           1h
 ske-operator-controller-manager      1/1     1            1           1h
 ```
 
+For SKE versions that include the Platform Manager, you will also see a `ske-platform-manager` deployment, which manages SKE upgrade plans and runs:
+
+```shell-session
+ske-platform-manager                 1/1     1            1           1h
+```
+
 You can now proceed with the configuration of Kratix (i.e. registering destinations or
 installing promises). For that, refer to the Open-Source Kratix documentation.
 
@@ -473,6 +479,12 @@ You should see the following output:
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 kratix-platform-controller-manager   1/1     1            1           1h
 ske-operator-controller-manager      1/1     1            1           1h
+```
+
+For SKE versions that include the Platform Manager, you will also see a `ske-platform-manager` deployment, which manages SKE upgrade plans and runs:
+
+```shell-session
+ske-platform-manager                 1/1     1            1           1h
 ```
 
 You can now proceed with the configuration of Kratix (i.e. registering destinations or

--- a/docs/ske/03-reference/02-ske-operator.mdx
+++ b/docs/ske/03-reference/02-ske-operator.mdx
@@ -51,6 +51,7 @@ resource is managed by the SKE Operator.
           name: my-issuer
       certSecretName: my-tls-secret # Required if cert-manager is disabled
       metricsServerCertSecretName: my-metrics-secret # Required if cert-manager is disabled
+      platformManagerCertSecretName: my-platform-manager-secret # Required if cert-manager is disabled from SKE VERSION-X
     deploymentConfig:
       resources: # Customize resource requests & limits for the Kratix deployment
         limits:

--- a/docs/ske/03-reference/02-ske-operator.mdx
+++ b/docs/ske/03-reference/02-ske-operator.mdx
@@ -51,7 +51,7 @@ resource is managed by the SKE Operator.
           name: my-issuer
       certSecretName: my-tls-secret # Required if cert-manager is disabled
       metricsServerCertSecretName: my-metrics-secret # Required if cert-manager is disabled
-      platformManagerCertSecretName: my-platform-manager-secret # Required if cert-manager is disabled from SKE VERSION-X
+      platformManagerCertSecretName: my-platform-manager-secret # Required if cert-manager is disabled and the SKE version includes the SKE Platform Manager
     deploymentConfig:
       resources: # Customize resource requests & limits for the Kratix deployment
         limits:

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -23,7 +23,7 @@ Check the release notes below for information on each available version.
 
 #### Features
 
-* Introduces the SKE Platform Manager, a new component that manages SKE upgrade plans and runs. The Platform Manager runs its own webhook server; when using the SKE Operator with cert-manager disabled, a separate TLS certificate for the Platform Manager is now required. For information on configuring the required certificates, see the [installation documentation](/ske/installing-ske/advanced-install#custom-certs). For more information on upgrades, see the [upgrades documentation](/ske/reference/promise-upgrades).
+* Introduces the SKE Platform Manager, a new component that manages SKE upgrade plans and runs. The Platform Manager runs its own webhook server; when using the SKE Operator with cert-manager disabled, a separate TLS certificate for the Platform Manager is now required. For information on configuring the required certificates, see the [installation documentation](/ske/installing-ske/advanced-install#custom-certs).
 * Destinations now surface a warning when referencing a StateStore that does not exist.
 
 #### Maintenance

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,12 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [VERSION-X](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/VERSION-X/) (DATE-X)
+
+#### Features
+
+* Introduces the SKE Platform Manager, a new component that manages SKE upgrade plans and runs. The Platform Manager runs its own webhook server; when using the SKE Operator with cert-manager disabled, a separate TLS certificate for the Platform Manager is now required. For information on configuring the required certificates, see the [installation documentation](/ske/installing-ske/advanced-install#custom-certs). For more information on upgrades, see the [upgrades documentation](/ske/reference/promise-upgrades).
+
 ### [v0.51.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.51.0/) (2026-07-07)
 
 #### Features

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,11 +19,16 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
-### [VERSION-X](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/VERSION-X/) (DATE-X)
+### [v0.52.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.52.0/) (2026-07-13)
 
 #### Features
 
 * Introduces the SKE Platform Manager, a new component that manages SKE upgrade plans and runs. The Platform Manager runs its own webhook server; when using the SKE Operator with cert-manager disabled, a separate TLS certificate for the Platform Manager is now required. For information on configuring the required certificates, see the [installation documentation](/ske/installing-ske/advanced-install#custom-certs). For more information on upgrades, see the [upgrades documentation](/ske/reference/promise-upgrades).
+* Destinations now surface a warning when referencing a StateStore that does not exist.
+
+#### Maintenance
+
+* Base image updates and package maintenance.
 
 ### [v0.51.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.51.0/) (2026-07-07)
 


### PR DESCRIPTION
## Summary

Based on Sapphire's WIP branch (`feat/ske-platform-manager`), rebased onto current main.

- Adds v0.52.0 release notes entry to `10-ske.mdx` including SKE Platform Manager feature and StateStore warning
- Adds `ske-platform-manager` deployment callout to both verify sections in `02-advanced-install.mdx`
- Adds `platformManagerCertSecretName` to the SKE Operator reference doc
- Preserves v0.51.0, v0.30.0, and v0.30.1 entries that merged since Sapphire's branch was cut

## Merge order — important

**Do not merge until:**
1. SKE v0.52.0 has been promoted and the release tag confirmed on `syntasso/enterprise-kratix`
2. PR #550 (UpgradePlan/UpgradeRun docs) has been merged — this PR links to `/ske/reference/promise-upgrades` which PR #550 creates

CI will fail on this PR until #550 is merged (broken link check). That is expected — merge #550 first.

## Related

- Sapphire's original branch: `feat/ske-platform-manager`
- PR #550 (UpgradePlan/UpgradeRun docs) — merge before this one