### PR TITLE
chore: add pointers to release pages and make comments more helpful

### DIFF
--- a/docs/ske/01-installing-ske/02-advanced-install.mdx
+++ b/docs/ske/01-installing-ske/02-advanced-install.mdx
@@ -158,8 +158,14 @@ To configure the version of SKE that the operator will install, you can use the
 
 ```yaml
 skeDeployment:
-  version: v0.99.0 # select your desired version
+  version: v0.99.0 # replace this placeholder version with your desired version of SKE
 ```
+
+:::tip
+
+For the latest available versions, see the [SKE releases](/ske/releases/ske) page.
+
+:::
 
 #### Custom Certs {#custom-certs}
 
@@ -452,8 +458,14 @@ kind: Kratix
 metadata:
   name: my-kratix
 spec:
-  version: v0.99.0 # The desired version of SKE
+  version: v0.99.0 # replace this placeholder version with your desired version of SKE
 ```
+
+:::tip
+
+For the latest available versions, see the [SKE releases](/ske/releases/ske) page.
+
+:::
 
 Apply the file with `kubectl`:
 

--- a/docs/ske/10-integrations/10-backstage/03-installation/03-generating-backstage-components.mdx
+++ b/docs/ske/10-integrations/10-backstage/03-installation/03-generating-backstage-components.mdx
@@ -70,7 +70,7 @@ metadata:
   name: backstage-integration
 spec:
   type: backstage
-  version: v0.99.0 # The desired version of the Backstage Controller
+  version: v0.99.0 # replace this placeholder version with your desired version of the Backstage Controller
   deploymentConfig:
     resources:
       limits:
@@ -80,6 +80,12 @@ spec:
         memory: "256Mi"
         cpu: "100m"
 ```
+
+:::tip
+
+For the latest available versions, see the [Backstage Controller releases](/ske/releases/backstage-controller) page.
+
+:::
 
 Apply the file with kubectl:
 

--- a/docs/ske/10-integrations/11-cortex/01-installation.mdx
+++ b/docs/ske/10-integrations/11-cortex/01-installation.mdx
@@ -168,7 +168,7 @@ metadata:
   name: cortex-integration
 spec:
   type: cortex
-  version: v0.99.0 # The desired version of the Controller
+  version: v0.99.0 # replace this placeholder version with your desired version of the Cortex Controller
   cortex:
     branch: main # any branch that exists; defaults to main
     integrationAlias: my-alias # needs to match the integrationAlias for your GitOps integration
@@ -184,6 +184,12 @@ spec:
         memory: "256Mi"
         cpu: "100m"
 ```
+
+:::tip
+
+For the latest available versions, see the [Cortex Controller releases](/ske/releases/cortex-controller) page.
+
+:::
 
 Apply the file with kubectl:
 


### PR DESCRIPTION
Change the comments to clarify that the suggested versions are a placeholder and that the desired component version should be retrieved from the release pages, with a tip pointing to them.

This addresses installation issues seem by customers in PoVs, where they copy and paste the value without checking and the docs aren't explicit enough to emphasise that they need to actively add the version they want to install to the Helm Chart values.