### PR TITLE
docs(ske): release notes for v0.53.0

### DIFF
--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -24,7 +24,7 @@ Check the release notes below for information on each available version.
 #### Features
 
 * S3-compatible release storage now supports path-style addressing via `spec.releaseStorage.forcePathStyle`. Enable this for stores that do not support virtual-hosted-style addressing, such as an in-cluster MinIO instance.
-* Delete workflows can now pause execution using the `wait` step, giving platform teams control over deletion ordering and dependencies.
+* Delete workflows can now pause execution using the `wait` step, giving platform teams control over deletion ordering and dependencies. See [Gating Deletion with Workflow Control](https://docs.kratix.io/main/guides/gating-deletion-with-workflow-control).
 
 #### Maintenance
 

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,21 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [v0.53.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.53.0/) (2026-07-22)
+
+#### Features
+
+* S3-compatible release storage now supports path-style addressing via `spec.releaseStorage.forcePathStyle`. Enable this for stores that do not support virtual-hosted-style addressing, such as an in-cluster MinIO instance.
+* Delete workflows can now pause execution using the `wait` step, giving platform teams control over deletion ordering and dependencies.
+
+#### Fixes
+
+* Fixed an issue on AKS where the API server webhook caused infinite reconciliation loops on certain resources.
+
+#### Maintenance
+
+* Base image updates and package maintenance.
+
 ### [v0.52.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.52.0/) (2026-07-13)
 
 #### Features

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -26,10 +26,6 @@ Check the release notes below for information on each available version.
 * S3-compatible release storage now supports path-style addressing via `spec.releaseStorage.forcePathStyle`. Enable this for stores that do not support virtual-hosted-style addressing, such as an in-cluster MinIO instance.
 * Delete workflows can now pause execution using the `wait` step, giving platform teams control over deletion ordering and dependencies.
 
-#### Fixes
-
-* Fixed an issue on AKS where the API server webhook caused infinite reconciliation loops on certain resources.
-
 #### Maintenance
 
 * Base image updates and package maintenance.


### PR DESCRIPTION
Release notes for SKE v0.53.0.

## What's included

**Features:**
- `spec.releaseStorage.forcePathStyle` — S3 path-style addressing for non-AWS stores (e.g. in-cluster MinIO)
- Delete workflows wait step — pause execution during deletion for ordering control (Kratix commit bab8949, bundled in this release)

**Fixes:**
- AKS infinite reconciliation loop fix (#1123 in enterprise-kratix)

**Maintenance:** base image updates

## What's excluded and why

- **Portal controller** — code is in enterprise-kratix at this tag but the image is not published and the component is not in `ske-distribution.yaml`. Not customer-deployable yet.
- **matchAll selector** (PR #564 in this repo) — the feature landed in enterprise-kratix on 2026-07-20 (PR #1145), after v0.53.0-rc1 was cut on 2026-07-14. Not in this release.
- **ske-operator, backstage-controller, CLI** — separate release pages.

## Merge order

Do NOT merge until the full release tag `v0.53.0` exists on `syntasso/enterprise-kratix`. Merge feature docs PRs first, this PR last.