### PR TITLE
docs(ske): document Health Definition namespace and security context

### DIFF
--- a/docs/ske/03-reference/04-health-definition.md
+++ b/docs/ske/03-reference/04-health-definition.md
@@ -50,3 +50,65 @@ spec:
         - image: ghcr.io/myorg/health-check
           name: health
 ```
+
+## Namespace
+
+The Health Agent creates the `CronJob` — along with the `ServiceAccount` and RBAC it needs — in the
+**same namespace as the `HealthDefinition`**, and the Health Check runs there. This is independent
+of `spec.resourceRef.namespace`, which identifies the Resource being checked and may live in a
+different namespace.
+
+## Security context
+
+The Health Agent runs each Health Check as a Kubernetes `CronJob`, and the pods it generates are
+**non-root by default**:
+
+- the pod is given a pod-level `securityContext` of `runAsNonRoot: true` and
+  `seccompProfile.type: RuntimeDefault`, which every container inherits;
+- the containers the agent injects (its `reader` and `health-state-creator`) are fully hardened
+  with `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`, `runAsNonRoot: true` and
+  `seccompProfile.type: RuntimeDefault`.
+
+This lets Health Checks run on clusters that mandate `runAsNonRoot` (for example a Gatekeeper
+policy or the `restricted` Pod Security Standard) without any extra configuration, as long as your
+own workflow image can run as a non-root user.
+
+### Overriding the default per container
+
+Your workflow containers inherit the non-root default, but you can override it per container via
+`spec.workflow.spec.containers[].securityContext`. The agent passes whatever you declare through
+unchanged.
+
+You **must** override when your workflow image runs as root (many general-purpose utility images,
+such as `ghcr.io/syntasso/kratix-pipeline-utility`, do). Otherwise the kubelet refuses to start the
+container under the non-root default and the Health Check never runs. Which override you use
+depends on the cluster:
+
+- **Where non-root is mandatory** (Gatekeeper / `restricted` Pod Security Standard) — run as a
+  non-root user by setting `runAsUser` to a non-zero UID. These policies reject
+  `runAsNonRoot: false`.
+
+  ```yaml
+  workflow:
+    spec:
+      containers:
+        - image: bitnami/kubectl
+          name: health
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534 # "nobody"
+            runAsGroup: 65534 # "nogroup"
+  ```
+
+- **Where root is permitted** (for example a local cluster with no admission policy) — opt out of
+  the non-root default:
+
+  ```yaml
+  workflow:
+    spec:
+      containers:
+        - image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+          name: health
+          securityContext:
+            runAsNonRoot: false
+  ```

--- a/docs/ske/05-guides/10-healthchecks.mdx
+++ b/docs/ske/05-guides/10-healthchecks.mdx
@@ -324,6 +324,16 @@ rbac:
     resources: ["statefulsets"]
 ```
 
+:::info
+
+Health Check pods run **non-root by default**. If your workflow image runs as root (many
+general-purpose utility images do), the container will not start until you override its
+`securityContext` — set `runAsUser` to a non-zero UID on clusters that mandate non-root, or
+`runAsNonRoot: false` where root is permitted. See
+[Health Definition: Security context](/ske/reference/healthdefinition#security-context) for details.
+
+:::
+
 The updated script will look like this:
 
 ```yaml


### PR DESCRIPTION
## What

Documents two Health Agent behaviours for SKE:

1. **Namespace** — the Health Agent creates the `CronJob` (and its `ServiceAccount`/RBAC) in, and runs the Health Check in, the **same namespace as the `HealthDefinition`** — independent of `spec.resourceRef.namespace`.
2. **Security context** — Health Check pods are **non-root by default** (pod-level `runAsNonRoot` + hardened agent-owned containers). Workflow containers inherit this and can override per container; a root workflow image (e.g. `kratix-pipeline-utility`) must opt out — `runAsUser` on policy-enforcing clusters, `runAsNonRoot: false` where root is allowed.

## Where

- `docs/ske/03-reference/04-health-definition.md` — new **Namespace** and **Security context** sections.
- `docs/ske/05-guides/10-healthchecks.mdx` — an `:::info` admonition by the RBAC step linking to the reference.

British English per `AGENTS.md`. `yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)