### PR TITLE
docs(ske): release notes for k8s-health-agent v0.11.0

### DIFF
--- a/docs/ske/50-releases/21-ske-health-agent.mdx
+++ b/docs/ske/50-releases/21-ske-health-agent.mdx
@@ -22,12 +22,12 @@ Released in Helm Chart version [0.25.0](http://syntasso-enterprise-releases.s3-w
 
 #### Features
 
-* Health Check pods now run with a restricted, non-root pod-level security context by default, and the agent-owned containers are hardened. Workflow containers inherit these defaults and can override them per container where a root image is required. See the [Security context](/ske/reference/health-definition) section of the Health Definition reference.
+* Health Check pods now run with a restricted, non-root pod-level security context by default, and the agent-owned containers are hardened. Workflow containers inherit these defaults and can override them per container where a root image is required. See the [Security context](/ske/reference/healthdefinition) section of the Health Definition reference.
 * `spec.inputs` on a `HealthDefinition` is now optional.
 
 #### Bug Fixes
 
-* The Health Agent now creates the `CronJob` (and its `ServiceAccount`/RBAC) in, and runs the Health Check in, the same namespace as the `HealthDefinition`, independent of `spec.resourceRef.namespace`. See the [Namespace](/ske/reference/health-definition) section of the Health Definition reference and the [Health checks guide](/ske/guides/healthchecks).
+* The Health Agent now creates the `CronJob` (and its `ServiceAccount`/RBAC) in, and runs the Health Check in, the same namespace as the `HealthDefinition`, independent of `spec.resourceRef.namespace`. See the [Namespace](/ske/reference/healthdefinition) section of the Health Definition reference and the [Health checks guide](/ske/guides/healthchecks).
 
 #### Security Fixes
 

--- a/docs/ske/50-releases/21-ske-health-agent.mdx
+++ b/docs/ske/50-releases/21-ske-health-agent.mdx
@@ -16,6 +16,23 @@ http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-heal
 
 ## Release Notes
 
+### [v0.11.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.11.0/) (2026-07-23)
+
+Released in Helm Chart version [0.25.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent-helm-chart/0.25.0/)
+
+#### Features
+
+* Health Check pods now run with a restricted, non-root pod-level security context by default, and the agent-owned containers are hardened. Workflow containers inherit these defaults and can override them per container where a root image is required. See the [Security context](/ske/reference/health-definition) section of the Health Definition reference.
+* `spec.inputs` on a `HealthDefinition` is now optional.
+
+#### Bug Fixes
+
+* The Health Agent now creates the `CronJob` (and its `ServiceAccount`/RBAC) in, and runs the Health Check in, the same namespace as the `HealthDefinition`, independent of `spec.resourceRef.namespace`. See the [Namespace](/ske/reference/health-definition) section of the Health Definition reference and the [Health checks guide](/ske/guides/healthchecks).
+
+#### Security Fixes
+
+* Dependency and security updates.
+
 ### [v0.10.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.10.0/) (2026-06-10)
 
 Released in Helm Chart version [0.24.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent-helm-chart/0.24.0/)


### PR DESCRIPTION
Adds the release-notes entry for **k8s-health-agent v0.11.0** to `docs/ske/50-releases/21-ske-health-agent.mdx`.

- Released in Helm Chart version 0.25.0 (both artifacts confirmed live in S3).
- Features: restricted non-root pod-level security context on Health Check pods; `spec.inputs` now optional.
- Bug Fixes: HealthDefinition namespace behaviour.
- Links to the reference/guide sections added in #580.

Batches with #580 (`k8s-health-agent-next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)