### PR TITLE
docs(ske): release notes for k8s-health-agent v0.11.1

### DIFF
--- a/docs/ske/50-releases/21-ske-health-agent.mdx
+++ b/docs/ske/50-releases/21-ske-health-agent.mdx
@@ -16,6 +16,18 @@ http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-heal
 
 ## Release Notes
 
+### [v0.11.1](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.11.1/) (2026-07-28)
+
+Released in Helm Chart version [0.26.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent-helm-chart/0.26.0/)
+
+#### Bug Fixes
+
+* Health records can now be written to a `BucketStateStore` using [`authMethod: IAM`](/main/reference/statestore/bucketstatestore#iam) on EKS, where resolving the IAM credentials previously failed.
+
+#### Maintenance
+
+* Base image updates.
+
 ### [v0.11.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.11.0/) (2026-07-23)
 
 Released in Helm Chart version [0.25.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent-helm-chart/0.25.0/)


### PR DESCRIPTION
Release notes for k8s-health-agent v0.11.1 (Helm Chart 0.26.0).

Source: syntasso/enterprise-kratix#1246 (merged 2026-07-28). Both artifacts confirmed live in S3.

`yarn build` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)