### PR TITLE
fix: update api version for flux resources

### DIFF
--- a/docs/main/04-guides/02-installing-gitops-agent/01-flux.mdx
+++ b/docs/main/04-guides/02-installing-gitops-agent/01-flux.mdx
@@ -63,7 +63,7 @@ resource depending on the type of state store you are using.
 
     ```yaml
     ---
-    apiVersion: source.toolkit.fluxcd.io/v1beta1
+    apiVersion: source.toolkit.fluxcd.io/v1
     kind: Bucket
     metadata:
       name: default-name
@@ -164,7 +164,7 @@ for more information.
 
 ```yaml
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-resources
@@ -180,7 +180,7 @@ spec:
   path: ./<path in state store to destination>/resources
   validation: client
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kratix-workload-dependencies

--- a/docs/main/04-guides/02-installing-gitops-agent/01-flux.mdx
+++ b/docs/main/04-guides/02-installing-gitops-agent/01-flux.mdx
@@ -178,7 +178,6 @@ spec:
     kind: <Bucket or GitRepository>
     name: default-name
   path: ./<path in state store to destination>/resources
-  validation: client
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -192,7 +191,6 @@ spec:
     kind: <Bucket or GitRepository>
     name: default-name
   path: ./<path in state store to destination>/dependencies
-  validation: client
 ```
 
 Once filled in with the correct values, apply the resource to the worker


### PR DESCRIPTION
## Description

small bug in the manifests inlined, latest flux now uses v1 for apiVersion 


## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
