### PR TITLE
docs(ske): release notes for k8s-health-agent v0.12.0

### DIFF
--- a/docs/ske/50-releases/21-ske-health-agent.mdx
+++ b/docs/ske/50-releases/21-ske-health-agent.mdx
@@ -16,6 +16,18 @@ http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-heal
 
 ## Release Notes
 
+### [v0.12.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.12.0/) (2026-07-29)
+
+Released in Helm Chart version [0.27.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent-helm-chart/0.27.0/)
+
+#### Bug Fixes
+
+* Health records can now be written to a [`BucketStateStore`](/main/reference/statestore/bucketstatestore) from IPv4-only networks. Amazon S3 endpoints were being rewritten to their dual-stack (IPv4/IPv6) variant, which is unreachable from an IPv4-only VPC; the configured endpoint is now used exactly as set.
+
+#### Maintenance
+
+* Base image updates.
+
 ### [v0.11.1](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent/v0.11.1/) (2026-07-28)
 
 Released in Helm Chart version [0.26.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#k8s-health-agent-helm-chart/0.26.0/)


### PR DESCRIPTION
Release notes for `k8s-health-agent` v0.12.0, released via [enterprise-kratix#1278](https://github.com/syntasso/enterprise-kratix/pull/1278).

Shipped in Helm Chart version 0.27.0 ([helm-charts#211](https://github.com/syntasso/helm-charts/pull/211)).

Both artifacts are confirmed live in S3:
- `k8s-health-agent/v0.12.0/`
- `k8s-health-agent-helm-chart/0.27.0/`

The `feat: bump kratix lib` changelog entry is filed under **Bug Fixes** rather than Features: it pulls in [syntasso/kratix@a10bdb2c](https://github.com/syntasso/kratix/commit/a10bdb2c66961828fb03ee32a34dc4b837afdc20), which stops minio-go rewriting Amazon S3 endpoints to their dual-stack variant. The new `useDualStack` toggle is not read by the agent's `health-state-store-config` ConfigMap, so there is no new user-facing option, only the fix.

No `k8s-health-agent-next` docs PRs accompany this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)