### PR TITLE
docs: add missing pre-creation ResourceBinding pinning feature to v0.54.0 release notes

### DIFF
--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -21,6 +21,10 @@ Check the release notes below for information on each available version.
 
 ### [v0.54.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.54.0/) (2026-08-04)
 
+#### Features
+
+* A Resource Binding can now be pre-created to pin a Resource Request to a specific Promise version at creation time. This is particularly useful for Compound Promises, where workflows output Resource Requests for component Promises. For more information, see [Pinning a Resource Request when it is created](/main/reference/promises/promise-upgrade/resource-bindings#pinning-a-resource-request-when-it-is-created).
+
 #### Fixes
 
 * Kratix now recovers when a Git State Store is changed outside of Kratix (for example a manual commit, or a Flux or Argo prune). Before each write, Kratix resets its cached clone to the latest remote state instead of rebasing, so writes always start from the true remote state. A new `git.minimumFetchInterval` [Kratix Config](https://docs.kratix.io/main/reference/kratix-config/config#git) option (default `5s`) bounds how often the remote is fetched.


### PR DESCRIPTION
Adds the missing Features section to the v0.54.0 entry. The ability to pre-create a ResourceBinding to pin a resource request's initial version was shipped in v0.54.0 (kratix#856) and documented in #591, but was not mentioned in the release notes.\n\nAdds:\n```\n#### Features\n* A Resource Binding can now be pre-created to pin a Resource Request to a specific Promise version at creation time...\n```