### PR TITLE
docs(ske): release notes for SKE v0.55.0

### DIFF
--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -81,6 +81,7 @@ spec:
       operator: "Equal"
       value: "workflows"
       effect: "NoSchedule"
+  restartPolicy: OnFailure # Optional; restart policy for the pipeline Job Pod. Defaults to OnFailure
   volumes:
     - name: myvolume # Volume definitions, in addition to `/kratix` volumes (optional)
   containers:
@@ -137,6 +138,11 @@ is retried via the [`kratix` ConfigMap](/main/reference/kratix-config/config):
 * `backoffLimit` determines how many times Kubernetes retries a failing Job before
   marking it failed. Kratix does not set a default value for this field; if omitted,
   Kubernetes uses its own Job default.
+
+You can also control the [restart
+policy](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)
+of the pipeline Job Pod by setting `restartPolicy` in the Pipeline spec. This
+defaults to `OnFailure`.
 
 #### Common Job signals
 

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,16 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [v0.55.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.55.0/) (TBD)
+
+#### Features
+
+* A new `workPlacementRewriteInterval` option in the Kratix Config controls how often WorkPlacements re-write their files to the state store to correct drift, independently of workflow runs. Set to `0` to disable periodic re-writes entirely. For more information, see the [Kratix Config](/main/reference/kratix-config/config#workplacementrewriteinterval-default-10h) documentation.
+
+#### Maintenance
+
+* Base image updates and package maintenance.
+
 ### [v0.54.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.54.0/) (2026-08-04)
 
 #### Features


### PR DESCRIPTION
## What's in this release

Release notes for SKE v0.55.0.

### Included

- **`workPlacementRewriteInterval`** (Kratix #860) — new Kratix Config option controlling how often WorkPlacements re-write files to the state store to correct drift, independent of workflow runs. Reference page being added via kratix-docs #597 (must merge before this PR).

### Pending — do not merge until resolved

- **`restartPolicy` in pipeline spec** (Kratix #861) — allows Promise writers to configure the `restartPolicy` on pipeline Job Pods. Feature is in the RC but has no reference docs yet. Checking with Sapphire (author of the kratix PR) on whether docs are coming. Will add a bullet once confirmed.

### Excluded and why

- **Portal adapter/controller changes** — `ske-portal-controller/**` commits are present in the RC but the portal-controller image is not in `ske-distribution.yaml`, so excluded per release notes policy.
- **Dry-run experimental** — already documented in ske-operator v0.33.0 release notes; not duplicated here.
- **`reconcileAfterFailure`** — docs merged early (PR #600) but the feature itself (Kratix #858/#862) is NOT in this RC. Excluded.

## Merge order

1. Merge kratix-docs #597 (workPlacementRewriteInterval ref page)
2. Merge this PR (last — it links to the ref page above)

(Promotion must happen before any docs merge — per policy, never merge docs before the release tag exists.)