### PR TITLE
docs: add missing MCP server tools to Available tools table

### DIFF
--- a/docs/ske/10-integrations/30-mcp.mdx
+++ b/docs/ske/10-integrations/30-mcp.mdx
@@ -116,12 +116,14 @@ The server provides the AI agent with the tools to answer these questions and, w
 | Tool | What it does |
 |---|---|
 | `fetch_promises` | List available Promises |
+| `guide_request_workflow` | Guide a full request workflow — discovery, planning, validation, and submit readiness — in one call |
 | `describe_promise_requestable` | Promise summary, schema, and submit hints in one view |
 | `fetch_ready_destinations` | Destinations that can accept requests |
 | `fetch_destination_contexts` | Which destinations match a Promise's placement selectors |
 | `fetch_full_promises` | Promises expanded with their matching resource instances |
 | `fetch_promise_requests` | Requests scoped to a single Promise |
 | `get_request_status` | Look up a single request by name and namespace |
+| `find_request_status` | Find a request's status without knowing its exact name; picks the most recent match |
 | `validate_promise_request` | OpenAPI-schema preflight check before submitting |
 | `submit_promise_request` | Create a namespaced request; stamps the requesting user and emits a Kubernetes Event |
 


### PR DESCRIPTION
## Summary
- `docs/ske/10-integrations/30-mcp.mdx`'s "Available tools" table listed 9 tools; `ske-mcp-server` main (tagged `v0.2.3`) actually registers 11 via `mcp.AddTool` across `internal/mcpserver/promise_tools.go`, `destination.go`, and `destination_context.go`.
- Adds the 2 missing rows: `guide_request_workflow` and `find_request_status`, with descriptions drawn from their tool descriptions in source.
- Found while verifying tool-name claims in [syntasso/enterprise-skills#17](https://github.com/syntasso/enterprise-skills/pull/17) against this doc — the doc was the source of an incorrect review comment until I checked the server source directly.

## Test plan
- [x] Diffed every `mcp.AddTool(...)` call in `ske-mcp-server` (main, `v0.2.3`) against this table — now 11/11 match.
- [ ] Someone with docs preview access confirms the table renders correctly.