### PR TITLE
docs: add a dedicated page for kratix controller rbac

### DIFF
--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -247,7 +247,8 @@ This applies to both Promise and Resource Configure workflows.
 ### Role-based Access Control (RBAC)
 
 Each pipeline runs with its own service account and a default set of restrictive
-RBAC permissions. By default the service account is automatically created by
+RBAC permissions, enumerated in [Default Permissions](#default-permissions)
+below. By default the service account is automatically created by
 Kratix and the name is deterministic. You have three options for providing
 additional [RBAC
 permissions](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to
@@ -266,6 +267,59 @@ the pipeline:
 
 The namespace a resource request pipeline runs in is the same as the namespace as the resource
 request. Promise pipelines run in the `kratix-platform-system` namespace.
+
+:::
+
+#### Default Permissions
+
+Alongside the [service account](#service-account), Kratix creates the RBAC objects a
+pipeline needs to write back `Work` objects and to update the Resource it is reconciling.
+These objects reuse the service account's name, so you can predict their names if you need
+to audit them or create your own. That name is
+`<promise-name>-<workflow-type>-<workflow-action>-<pipeline-name>`.
+
+The examples below are for a Promise named `env` publishing an `envs.example.org` Resource
+API.
+
+**Promise workflows** get a `ClusterRole` and `ClusterRoleBinding` named after the
+pipeline, for example `env-promise-configure-tf-workspace`. `Promise` and `Work` are
+cluster-scoped, so a namespaced `Role` cannot grant this access:
+
+```yaml
+rules:
+- apiGroups: [platform.kratix.io]
+  resources: [promises, promises/status, works]
+  verbs: [get, list, update, create, patch]
+```
+
+**Resource workflows** get a `Role` and `RoleBinding` in the pipeline's namespace, for
+example `env-resource-configure-slack-notify`:
+
+```yaml
+rules:
+- apiGroups: [example.org]           # the Promise's own API group
+  resources: [envs, envs/status]
+  verbs: [get, list, update, create, patch]
+- apiGroups: [platform.kratix.io]
+  resources: [works]
+  verbs: ["*"]
+```
+
+If the Promise sets [`pipelineNamespace`](#workflows-namespace), its Resource workflows run
+in a different namespace from the resource request. The permission then crosses a namespace
+boundary, so Kratix also creates a `ClusterRole` and `ClusterRoleBinding` containing the
+first rule above, named with the requesting namespace appended. For a request in the
+`team-a` namespace, this is `env-resource-configure-slack-notify-team-a`.
+
+Each of these objects carries the label `kratix.io/promise-name: <promise-name>`, and all of
+them are deleted when the Promise is deleted. Supplying a
+[custom service account](#custom-service-account) changes the service account name only.
+The Role and binding names are still derived from the pipeline.
+
+:::note
+
+If you are interested in the permissions the Kratix controller holds, 
+see [Kratix Control Plane Permissions](/main/platform-concepts/auth/control-plane-permissions).
 
 :::
 

--- a/docs/main/03-reference/12-workflows.md
+++ b/docs/main/03-reference/12-workflows.md
@@ -292,8 +292,7 @@ rules:
   verbs: [get, list, update, create, patch]
 ```
 
-**Resource workflows** get a `Role` and `RoleBinding` in the pipeline's namespace, for
-example `env-resource-configure-slack-notify`:
+**Resource workflows** get a `Role` and `RoleBinding` in the pipeline's namespace:
 
 ```yaml
 rules:
@@ -308,8 +307,8 @@ rules:
 If the Promise sets [`pipelineNamespace`](#workflows-namespace), its Resource workflows run
 in a different namespace from the resource request. The permission then crosses a namespace
 boundary, so Kratix also creates a `ClusterRole` and `ClusterRoleBinding` containing the
-first rule above, named with the requesting namespace appended. For a request in the
-`team-a` namespace, this is `env-resource-configure-slack-notify-team-a`.
+first rule above, named with the requesting namespace appended, following this format: 
+`<promise name>-resource-configure-<pipeline name>-<namespace>`.
 
 Each of these objects carries the label `kratix.io/promise-name: <promise-name>`, and all of
 them are deleted when the Promise is deleted. Supplying a

--- a/docs/main/05-platform-concepts/04-auth/02-rbac.mdx
+++ b/docs/main/05-platform-concepts/04-auth/02-rbac.mdx
@@ -15,6 +15,9 @@ recommended to review the Kubernetes documentation before proceeding.
 For how authentication fits into Kratix, see
 [Authentication](/main/platform-concepts/auth/authentication-oidc).
 
+This page covers access *to* Kratix. For the permissions the Kratix control plane itself
+requires, see [Kratix Control Plane Permissions](/main/platform-concepts/auth/control-plane-permissions).
+
 ## RBAC in Kratix
 
 Everything Kratix exposes is represented as a [Custom Resource Definition

--- a/docs/main/05-platform-concepts/04-auth/03-control-plane-permissions.mdx
+++ b/docs/main/05-platform-concepts/04-auth/03-control-plane-permissions.mdx
@@ -1,0 +1,67 @@
+---
+description: What permissions the Kratix control plane itself requires, and why
+title: Control Plane Permissions
+id: control-plane-permissions
+---
+
+This page describes the permissions Kratix itself needs in order to run.
+
+RBAC around Kratix works in two directions. Access *to* Kratix controls which users and
+service accounts may install Promises or request Resources, and is covered in
+[Role Based Access Control](/main/platform-concepts/auth/rbac). This page covers the other
+direction: the `ClusterRole` bound to the Kratix controller's ServiceAccount, what each
+grant is for, and which grants can be narrowed.
+
+## The Kratix controller ClusterRole
+
+Kratix runs as a single controller in the `kratix-platform-system` namespace, bound to a
+cluster-scoped `ClusterRole`. You can read the live definition at any time:
+
+```bash
+kubectl get clusterrole kratix-platform-manager-role -o yaml
+```
+
+| Grant | Verbs | Needed for |
+|---|---|---|
+| `apiextensions.k8s.io`: `customresourcedefinitions` | create, delete, get, list, patch, update, watch | Each Promise that publishes an API installs a CRD for its Resource kind. This is how a Promise becomes requestable. |
+| `platform.kratix.io`: `promises`, `works`, `workplacements`, `destinations`, `gitstatestores`, `bucketstatestores`, `resourcebindings`, `promisereleases`, `promiserevisions`, `healthrecords`, `dryruns` | create, delete, get, list, patch, update, watch | Kratix's own API. The same set is granted again for `/status` (get, patch, update) and `/finalizers` (update). |
+| `batch`: `jobs` | create, delete, get, list, patch, update, watch | Every workflow pipeline runs as a Job. |
+| `""`: `pods` | delete, get, list, watch | Reading pipeline pod state and logs, and removing completed pipeline pods. |
+| `""`: `configmaps` | create, delete, list, update, watch | Inputs Kratix mounts into pipeline containers, including Destination selectors. |
+| `""`: `serviceaccounts` | create, delete, get, list, update, watch | Each pipeline runs under its own ServiceAccount, created by Kratix. |
+| `""`: `secrets` | get, list, watch | Reading credentials referenced by StateStores and Destinations. Kratix does not create or modify Secrets. |
+| `""` / `events.k8s.io`: `events` | create, patch | Recording events against Promises and Resources. |
+| `rbac.authorization.k8s.io`: `roles`, `clusterroles` | bind, create, delete, escalate, get, list, update, watch | Creating each pipeline's permissions. See [below](#why-kratix-needs-escalate-and-bind). |
+| `rbac.authorization.k8s.io`: `rolebindings`, `clusterrolebindings` | create, delete, get, list, update, watch | Binding those permissions to the pipeline ServiceAccount. |
+
+For the objects Kratix generates for each pipeline, and the rules they contain, see
+[Default Permissions](/main/reference/workflows#default-permissions).
+
+## Why Kratix needs `escalate` and `bind`
+
+`escalate` and `bind` are verbs on `roles` and `clusterroles`. They are not verbs on
+`rolebindings` or `clusterrolebindings`.
+
+Kratix does not write `escalate` or `bind` into the roles it creates. They appear in no
+generated rule, and no pipeline ServiceAccount receives them. Kratix holds these verbs
+itself, and uses them at the point it creates a role.
+
+Kubernetes uses both verbs to prevent RBAC being used to grant yourself more than you
+already have. Two checks enforce this:
+
+- [Creating or updating a `Role` or `ClusterRole`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-creation-or-update)
+  requires that you already hold every permission you are writing into it. `escalate` waives
+  this check.
+- [Creating a binding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update)
+  requires that you hold every permission in the role being referenced. `bind` waives this
+  check, which is why it is a verb on the referenced role rather than on the binding.
+
+Kratix needs both because a Resource workflow's permissions include access to the
+Promise's own Resource kind. Those API groups do
+not exist until the Promise is installed, so they cannot be granted to Kratix in advance.
+Kratix therefore uses `escalate` and `bind` to grant a pipeline a permission that Kratix
+itself does not hold. The verbs are not passed on to the pipeline, so a pipeline pod cannot
+use them to escalate further.
+
+The RBAC objects Kratix generates with these verbs will always have deterministic names and a
+`kratix.io/promise-name: <promise-name>` label. They will be cleaned up with the deletion of the Promise.

--- a/docs/main/05-platform-concepts/04-auth/03-control-plane-permissions.mdx
+++ b/docs/main/05-platform-concepts/04-auth/03-control-plane-permissions.mdx
@@ -39,29 +39,13 @@ For the objects Kratix generates for each pipeline, and the rules they contain, 
 
 ## Why Kratix needs `escalate` and `bind`
 
-`escalate` and `bind` are verbs on `roles` and `clusterroles`. They are not verbs on
-`rolebindings` or `clusterrolebindings`.
-
-Kratix does not write `escalate` or `bind` into the roles it creates. They appear in no
-generated rule, and no pipeline ServiceAccount receives them. Kratix holds these verbs
-itself, and uses them at the point it creates a role.
-
-Kubernetes uses both verbs to prevent RBAC being used to grant yourself more than you
-already have. Two checks enforce this:
-
-- [Creating or updating a `Role` or `ClusterRole`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-creation-or-update)
-  requires that you already hold every permission you are writing into it. `escalate` waives
-  this check.
-- [Creating a binding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update)
-  requires that you hold every permission in the role being referenced. `bind` waives this
-  check, which is why it is a verb on the referenced role rather than on the binding.
-
 Kratix needs both because a Resource workflow's permissions include access to the
-Promise's own Resource kind. Those API groups do
-not exist until the Promise is installed, so they cannot be granted to Kratix in advance.
-Kratix therefore uses `escalate` and `bind` to grant a pipeline a permission that Kratix
-itself does not hold. The verbs are not passed on to the pipeline, so a pipeline pod cannot
-use them to escalate further.
+Promise's own Resource kind. Those API groups do not exist until the Promise is installed,
+so they cannot be granted to Kratix in advance. Kratix therefore needs `escalate` and `bind` 
+to grant a pipeline a permission that Kratix itself does not hold. The verbs are not passed
+on to the pipeline, so a pipeline pod cannot use them to escalate further.
 
 The RBAC objects Kratix generates with these verbs will always have deterministic names and a
 `kratix.io/promise-name: <promise-name>` label. They will be cleaned up with the deletion of the Promise.
+
+To learn more about `escalate` and `bind` permissions, check [Restrictions on Role Creation or Update](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-creation-or-update) and [Restrictions on Role Binding Creation and Update](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update) on the Kubernetes documentation.

--- a/docs/main/05-platform-concepts/04-auth/_category_.json
+++ b/docs/main/05-platform-concepts/04-auth/_category_.json
@@ -3,6 +3,6 @@
   "position": 8,
   "link": {
     "type": "generated-index",
-    "description": "How access to Kratix is authenticated and authorized."
+    "description": "How access to Kratix is authenticated and authorized, and what permissions the Kratix control plane itself requires."
   }
 }


### PR DESCRIPTION
## Description

This PR adds a dedicated page explaining kratix controller manager rbac.

It also document default pipeline permissions in the workflow reference page.

## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
