### PR TITLE
docs: note Compound Promises own their component versions

### DIFF
--- a/docs/main/03-reference/11-promises/07-compound.md
+++ b/docs/main/03-reference/11-promises/07-compound.md
@@ -79,6 +79,29 @@ To pin one to a specific version, create its
 [Resource Binding](./promise-upgrade/resource-bindings#pinning-a-resource-request-when-it-is-created)
 before the Resource Request.
 
+### The Compound Promise owns its component versions
+
+A Resource Binding output by your workflow is workflow output like any other: it is
+delivered to the Platform through the state store and applied by the GitOps agent. The
+agent restores whatever version the Compound Promise emitted, so a change made to the
+Binding outside the workflow does not survive the agent's next sync.
+
+The version of a component Resource is therefore a property of the Compound Promise, not
+of the component Resource. To move a component to a new version, change the version your
+Compound Promise workflow emits and upgrade the Compound Promise. Do not edit the
+component's Resource Binding directly.
+
+:::warning
+
+This applies to automated upgrades too. If you use SKE [Upgrade Plans and Upgrade
+Runs](/ske/reference/promise-upgrades/intro), exclude component Resources from your rollout
+groups — see [Excluding Compound Promise
+components](/ske/reference/promise-upgrades/upgrade-plans#excluding-compound-promise-components).
+An Upgrade Run patches the Binding and reports the Resource as upgraded, because
+`lastAppliedVersion` genuinely does reach the target. The GitOps agent then reverts it.
+
+:::
+
 ## Recommended ownership labels
 
 A typical Compound Promise will execute a Resource Configure workflow that will

--- a/docs/main/03-reference/11-promises/07-compound.md
+++ b/docs/main/03-reference/11-promises/07-compound.md
@@ -110,8 +110,7 @@ This applies to automated upgrades too. If you use SKE [Upgrade Plans and Upgrad
 Runs](/ske/reference/promise-upgrades/intro), exclude component Resources from your rollout
 groups — see [Excluding Compound Promise
 components](/ske/reference/promise-upgrades/upgrade-plans#excluding-compound-promise-components).
-An Upgrade Run patches the Binding and reports the Resource as upgraded, because
-`lastAppliedVersion` genuinely does reach the target. The GitOps agent then reverts it.
+An Upgrade Run will patch the Binding and report the Resource as upgraded. The GitOps agent will then revert the upgrade.
 
 :::
 

--- a/docs/main/03-reference/11-promises/07-compound.md
+++ b/docs/main/03-reference/11-promises/07-compound.md
@@ -89,6 +89,19 @@ Binding outside the workflow does not survive the agent's next sync.
 The version of a component Resource is therefore a property of the Compound Promise, not
 of the component Resource. To move a component to a new version, change the version your
 Compound Promise workflow emits and upgrade the Compound Promise. Do not edit the
+By default, Resource Requests produced by a Compound Promise workflow are served by the component
+Promise's `latest` Promise Revision, not by the version in `spec.requiredPromises`.
+To pin one to a specific version, create its
+[Resource Binding](./promise-upgrade/resource-bindings#pinning-a-resource-request-when-it-is-created) before the Resource Request.
+
+Note that the Resource Binding defined in a workflow is an output like any other: it will be 
+delivered to the Platform through the state store and applied by the GitOps agent. The
+agent restores whatever version the Compound Promise emitted, so a change made to the
+Binding outside the workflow does not survive the agent's next sync.
+
+In other words, the version of the component Resource is owned by the Compound Promise, not
+of the component Resource itself. To move a component to a new version, change the version your
+Compound Promise workflow emits and upgrade the Compound Promise. Do not edit the
 component's Resource Binding directly.
 
 :::warning

--- a/docs/ske/03-reference/03-promise-upgrades/01-upgrade-plans.md
+++ b/docs/ske/03-reference/03-promise-upgrades/01-upgrade-plans.md
@@ -232,7 +232,6 @@ include resources in a group.
 When a [Compound Promise](/main/reference/promises/compound) outputs Resource Bindings for its component Promises, the
 Compound Promise owns those versions. The Bindings reach the Platform through the state store, so the GitOps agent
 restores the version the Compound Promise emitted. An Upgrade Run that patches one of these Bindings records the
-Resource as **Succeeded** — `lastAppliedVersion` does reach the target — and the agent reverts it on its next sync.
 
 Do not include these Resources in your rollout groups, and do not upgrade them directly. Upgrade them by upgrading the
 Compound Promise that owns them. Label your component Resources so your selectors can exclude them; the Compound Promise

--- a/docs/ske/03-reference/03-promise-upgrades/01-upgrade-plans.md
+++ b/docs/ske/03-reference/03-promise-upgrades/01-upgrade-plans.md
@@ -227,6 +227,21 @@ include resources in a group.
 
 :::
 
+### Excluding Compound Promise components
+
+When a [Compound Promise](/main/reference/promises/compound) outputs Resource Bindings for its component Promises, the
+Compound Promise owns those versions. The Bindings reach the Platform through the state store, so the GitOps agent
+restores the version the Compound Promise emitted. An Upgrade Run that patches one of these Bindings records the
+Resource as **Succeeded** — `lastAppliedVersion` does reach the target — and the agent reverts it on its next sync.
+
+Do not include these Resources in your rollout groups, and do not upgrade them directly. Upgrade them by upgrading the
+Compound Promise that owns them. Label your component Resources so your selectors can exclude them; the Compound Promise
+documentation covers the [labels we recommend](/main/reference/promises/compound#recommended-ownership-labels) for this.
+
+This applies only to Bindings created by the Compound Promise's workflow. When a Compound Promise outputs only Resource
+Requests and lets Kratix create the Bindings, those Resources are managed like any other and can be upgraded with a
+plan.
+
 ### Max Concurrent
 
 The `maxConcurrent` field limits how many resources within a group are upgraded at the same time. It accepts either an


### PR DESCRIPTION
## Context

Document to skip upgrading component request directly if their versions are controlled via compound promises pinning resource bindings.