### PR TITLE
docs: ske-mcp-server v0.2.3 release notes

### DIFF
--- a/docs/ske/50-releases/30-integrations/40-ske-mcp-server.mdx
+++ b/docs/ske/50-releases/30-integrations/40-ske-mcp-server.mdx
@@ -25,6 +25,12 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+## [0.2.3](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-mcp-server/v0.2.3/) (2026-08-18)
+
+### Features
+
+* Added foundational OAuth 2.1 support for authenticating MCP clients.
+
 ## [0.2.2](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske-mcp-server/v0.2.2/) (2026-06-04)
 
 ### Features


### PR DESCRIPTION
## Summary
- Adds release notes for `ske-mcp-server` v0.2.3 (S3 confirmed live).
- Feature summarized as foundational OAuth 2.1 support, kept high-level/customer-facing per the underlying work (OAuth 2.1 resource-server foundations, not yet a customer-visible auth requirement change).

No other `-next` docs PRs found for this component to batch in.