### PR TITLE
chore: update minio for seaweedfs in the docs

### DIFF
--- a/blog/2025-04-16-backstage-keycloak/index.mdx
+++ b/blog/2025-04-16-backstage-keycloak/index.mdx
@@ -217,7 +217,7 @@ Now, from the Kratix repository, run:
 ```bash
 KIND_PLATFORM_CONFIG=/path/to/config.yaml \
   ./scripts/quick-start.sh \
-  --git-and-minio \
+  --git-and-bucket \
   --recreate
 ```
 

--- a/docs/_partials/_writing-a-promise.md
+++ b/docs/_partials/_writing-a-promise.md
@@ -553,7 +553,7 @@ At this point, your Promise directory structure should look like:
 
 <br />
 
-Before installing your Promise, verify that Kratix and MinIO are installed and
+Before installing your Promise, verify that Kratix and SeaweedFS are installed and
 healthy.
 
 :::tip
@@ -576,7 +576,6 @@ You should see something similar to
 ```console
 NAME                                                  READY   STATUS       RESTARTS   AGE
 kratix-platform-controller-manager-769855f9bb-8srtj   2/2     Running      0          1h
-minio-6f75d9fbcf-5cn7w                                1/1     Running      0          1h
 ```
 
 If that is not the case, please go back to [Prepare your

--- a/docs/_partials/_writing-a-promise.md
+++ b/docs/_partials/_writing-a-promise.md
@@ -578,6 +578,20 @@ NAME                                                  READY   STATUS       RESTA
 kratix-platform-controller-manager-769855f9bb-8srtj   2/2     Running      0          1h
 ```
 
+SeaweedFS runs in its own namespace, so check it separately:
+
+```bash
+kubectl --context $PLATFORM get pods --namespace seaweedfs
+```
+
+```console
+NAME                         READY   STATUS    RESTARTS   AGE
+seaweedfs-64c868686c-6fklj   2/2     Running   0          1h
+```
+
+Both containers should be ready. The Pod does not report `Ready` until the
+`kratix` bucket exists, so `2/2` also confirms the bucket is there.
+
 If that is not the case, please go back to [Prepare your
 environment](#prepare-your-environment) and follow the instructions.
 

--- a/docs/_partials/installation/_install-kratix-and-cert.mdx
+++ b/docs/_partials/installation/_install-kratix-and-cert.mdx
@@ -12,7 +12,7 @@ or permanent environments.
 If you are just getting started and have access to a disposable/empty cluster we highly
 recommend you get started with the [quick start](../../main/quick-start) instructions
 which can be used on all Kubernetes clusters and configures a Kratix and its first
-Destination and State Store backed by MinIO which is configured for learning but is not
+Destination and State Store backed by SeaweedFS which is configured for learning but is not
 robust or durable enough for production use.
 
 :::

--- a/docs/_partials/installation/_single-cluster-install.md
+++ b/docs/_partials/installation/_single-cluster-install.md
@@ -4,8 +4,8 @@ Install Kratix and its Dependencies with the command below:
 kubectl apply --filename https://github.com/syntasso/kratix/releases/latest/download/install-all-in-one.yaml
 ```
 
-The above will install Kratix, MinIO, and a GitOps agent. MinIO will be the [State Store](/main/reference/statestore/intro)
-for the Kratix to write to and the GitOps agent will watch the MinIO Bucket for any changes that need to be applied to
+The above will install Kratix, SeaweedFS, and a GitOps agent. SeaweedFS will be the [State Store](/main/reference/statestore/intro)
+for the Kratix to write to and the GitOps agent will watch the SeaweedFS Bucket for any changes that need to be applied to
 the cluster. Kratix supports a variety of [State Stores](/main/reference/statestore/intro)
 and multiple different State Stores can be used.
 

--- a/docs/_partials/workshop/_verify-kratix-without-promises.md
+++ b/docs/_partials/workshop/_verify-kratix-without-promises.md
@@ -1,5 +1,5 @@
 Following the previous step of this tutorial, you should now
-have a deployment of both Kratix and MinIO running on your platform cluster
+have a deployment of both Kratix and SeaweedFS running on your platform cluster
 with no installed Promises.
 
 You should also have two environment variables, `PLATFORM` and `WORKER`.
@@ -18,11 +18,21 @@ The above command will give an output similar to:
 ```shell-session
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 kratix-platform-controller-manager   1/1     1            1           1h
-minio                                1/1     1            1           1h
+```
+
+SeaweedFS runs in its own namespace, so check it separately:
+
+```bash
+kubectl --context $PLATFORM get deployments --namespace seaweedfs
+```
+
+```shell-session
+NAME        READY   UP-TO-DATE   AVAILABLE   AGE
+seaweedfs   1/1     1            1           1h
 ```
 
 You should also have a State Store created and configured to point to the
-`kratix` bucket on MinIO. Verify the `bucketstatestores`:
+`kratix` bucket on SeaweedFS. Verify the `bucketstatestores`:
 
 ```bash
 kubectl --context $PLATFORM get bucketstatestores.platform.kratix.io

--- a/docs/main/01-quick-start.md
+++ b/docs/main/01-quick-start.md
@@ -43,7 +43,7 @@ Kubernetes distribution including:
 
 If you're working in a shared or production-like environment, see the full
 [installation guide](/category/installing-kratix) to avoid configuration conflicts. The
-quick start deploys a local, insecure MinIO instance—intended only for local development.
+quick start deploys a local, insecure SeaweedFS instance—intended only for local development.
 
 ## Installation
 
@@ -67,10 +67,10 @@ quick-start that uses a single job to install Kratix with sensible defaults.
       Kratix webhooks
   1. Deploys the [**Kratix API server and controllers**](https://docs.kratix.io/main/platform-concepts/kratix-resources)
       in the `kratix-system` namespace
-  1. Deploys [**MinIO**](https://min.io/), a local S3-compatible bucket for storing
+  1. Deploys [**SeaweedFS**](https://seaweedfs.com/), a local S3-compatible bucket for storing
       declarative workloads
   1. Installs and configures [**Flux**](https://fluxcd.io/) to apply changes from the
-      MinIO bucket via GitOps
+      SeaweedFS bucket via GitOps
   1. Registers your Kubernetes cluster as a [**Destination**](https://docs.kratix.io/main/reference/destinations/intro)
       so Kratix can schedule workloads to it
 </details>
@@ -243,7 +243,7 @@ GitOps repository. In this case the workflow for the PostgreSQL Promise was
 quite simple, it took the users input and used this to generate the required
 Kubernetes resources to create the PostgreSQL instance. Those resources were
 then scheduled to the Platform via the GitOps repo (in this simple scenario, an
-in-cluster s3 compatible bucket using MinIO). GitOps can take some time to
+in-cluster s3 compatible bucket using SeaweedFS). GitOps can take some time to
 sync, so it may take up to a minute or two before you see the Pod for the
 PostgreSQL instance
 

--- a/docs/main/01-quick-start.md
+++ b/docs/main/01-quick-start.md
@@ -67,7 +67,7 @@ quick-start that uses a single job to install Kratix with sensible defaults.
       Kratix webhooks
   1. Deploys the [**Kratix API server and controllers**](https://docs.kratix.io/main/platform-concepts/kratix-resources)
       in the `kratix-system` namespace
-  1. Deploys [**SeaweedFS**](https://seaweedfs.com/), a local S3-compatible bucket for storing
+  1. Deploys [**SeaweedFS**](https://github.com/seaweedfs/seaweedfs), a local S3-compatible bucket for storing
       declarative workloads
   1. Installs and configures [**Flux**](https://fluxcd.io/) to apply changes from the
       SeaweedFS bucket via GitOps

--- a/docs/main/03-reference/14-statestore/03-bucketstatestore.md
+++ b/docs/main/03-reference/14-statestore/03-bucketstatestore.md
@@ -38,7 +38,7 @@ Any S3-Compatible provider will work with Kratix. See the documentation on how
 to use some of the available providers below:
 - [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html)
 - [GCS S3-compatible storage](https://cloud.google.com/storage/docs/interoperability)
-- [MinIO](https://min.io/docs/minio/linux/reference/minio-mc/mc-mb.html)
+- [SeaweedFS](https://github.com/seaweedfs/seaweedfs/wiki/Amazon-S3-API)
 
 For other providers, please check their documentation for setting up a bucket and its credentials.
 
@@ -64,17 +64,17 @@ kind: BucketStateStore
 metadata:
   name: default
 spec:
-  endpoint: minio.kratix-platform-system.svc.cluster.local
+  endpoint: bucket.seaweedfs.svc.cluster.local
   insecure: true
   bucketName: kratix
   secretRef:
-    name: minio-credentials
+    name: bucket-credentials
     namespace: default
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-credentials
+  name: bucket-credentials
   namespace: default
 type: Opaque
 data:

--- a/docs/main/03-reference/14-statestore/03-bucketstatestore.md
+++ b/docs/main/03-reference/14-statestore/03-bucketstatestore.md
@@ -38,7 +38,7 @@ Any S3-Compatible provider will work with Kratix. See the documentation on how
 to use some of the available providers below:
 - [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html)
 - [GCS S3-compatible storage](https://cloud.google.com/storage/docs/interoperability)
-- [SeaweedFS](https://github.com/seaweedfs/seaweedfs/wiki/Amazon-S3-API)
+- [SeaweedFS](https://github.com/seaweedfs/seaweedfs)
 
 For other providers, please check their documentation for setting up a bucket and its credentials.
 

--- a/docs/main/04-guides/01-installing-kratix/04-openshift.mdx
+++ b/docs/main/04-guides/01-installing-kratix/04-openshift.mdx
@@ -43,7 +43,6 @@ Some users have reported issues with accessing the
 kubectl -n kratix-platform-system get pods
 NAME                                                 READY   STATUS             RESTARTS   AGE
 kratix-platform-controller-manager-7698bb84d-82dfm   0/1     ImagePullBackOff   0          95s
-minio-54f847c6c5-4t9jb                               1/1     Running            0          93s
 
 kubectl -n kratix-platform-system describe pod kratix-platform-controller-manager-7698bb84d-82dfm
 ...

--- a/docs/main/04-guides/01-installing-kratix/05-others.mdx
+++ b/docs/main/04-guides/01-installing-kratix/05-others.mdx
@@ -35,7 +35,7 @@ or want to use a different tool to provision your clusters, skip requirements 1 
 
 To get setup locally quickly with KinD clusters you can use the `./scripts/quick-start.sh`
 from the root of the [Kratix repository](https://github.com/syntasso/kratix). This provisions
-an in-cluster `MinIO` to use as the backing [State Store](/main/reference/statestore/intro).
+an in-cluster `SeaweedFS` to use as the backing [State Store](/main/reference/statestore/intro).
 Alternatively you can provide the `--git` flag to create it with an in-cluster Gitea
 instance instead.
 
@@ -55,14 +55,14 @@ export PLATFORM="kind-platform"
 
 <PartialInstallStateStoreStart />
 
-If your are using local KinD clusters you can install MinIO or Gitea as an in-cluster State Store.
+If your are using local KinD clusters you can install SeaweedFS or Gitea as an in-cluster State Store.
 
 <Tabs className="boxedTabs" groupId="stateStore">
-  <TabItem value="minio" label="Bucket (on KinD)">
+  <TabItem value="bucket" label="Bucket (on KinD)">
 
   ```bash
-  # Install MinIO and register it as a BucketStateStore
-  kubectl apply --context $PLATFORM --filename https://raw.githubusercontent.com/syntasso/kratix/main/config/samples/minio-install.yaml
+  # Install SeaweedFS and register it as a BucketStateStore
+  kubectl apply --context $PLATFORM --filename https://raw.githubusercontent.com/syntasso/kratix/main/config/samples/seaweedfs-install.yaml
   kubectl apply --context $PLATFORM --filename https://raw.githubusercontent.com/syntasso/kratix/main/config/samples/platform_v1alpha1_bucketstatestore.yaml
   ```
 

--- a/docs/main/04-guides/01-installing-kratix/05-others.mdx
+++ b/docs/main/04-guides/01-installing-kratix/05-others.mdx
@@ -45,7 +45,7 @@ instance instead.
 
 If you are not using a pre-existing cluster, create your platform cluster locally using KinD:
 ```bash
-kind create cluster --image kindest/node:v1.27.3 --name platform
+kind create cluster --image kindest/node:v1.33.1 --name platform
 # set PLATFORM to point to the platform cluster context
 export PLATFORM="kind-platform"
 ```
@@ -99,7 +99,7 @@ If your are using local KinD clusters you can install SeaweedFS or Gitea as an i
 ### Create worker cluster
 If you are not using a pre-existing cluster, create your worker cluster locally using KinD:
 ```bash
-kind create cluster --image kindest/node:v1.27.3 --name worker
+kind create cluster --image kindest/node:v1.33.1 --name worker
 
 # set WORKER to point to the worker cluster context
 export WORKER="kind-worker"

--- a/docs/main/04-guides/02-installing-gitops-agent/01-flux.mdx
+++ b/docs/main/04-guides/02-installing-gitops-agent/01-flux.mdx
@@ -46,16 +46,16 @@ resource depending on the type of state store you are using.
 
 <Tabs className="boxedTabs" groupId="stateStore">
 
-  <TabItem value="minio" label="Bucket (on KinD)">
+  <TabItem value="bucket" label="Bucket (on KinD)">
 
-    Create a `flux-statestore.yaml` for giving Flux access to the Minio
-    bucket. Below is an example of a `Bucket` configured to talk to a MinIO
+    Create a `flux-statestore.yaml` for giving Flux access to the SeaweedFS
+    bucket. Below is an example of a `Bucket` configured to talk to a SeaweedFS
     instance running locally. For more information on the different
     configuration and authentication options for the `Bucket` resource, see the
     [FluxCD docs](https://fluxcd.io/flux/components/source/buckets/).
 
     :::info
-    This example depends on a secret called `minio-credentials` existing in the
+    This example depends on a secret called `bucket-credentials` existing in the
     `flux-system` namespace. This is only necessary if the repository is private
     and there are a number of authentication options described in the
     [FluxCD docs](https://fluxcd.io/flux/components/source/gitrepositories/#secret-reference).
@@ -75,12 +75,12 @@ resource depending on the type of state store you are using.
       endpoint: 172.18.0.2:31337
       insecure: true
       secretRef:
-        name: minio-credentials
+        name: bucket-credentials
     ---
     apiVersion: v1
     kind: Secret
     metadata:
-      name: minio-credentials
+      name: bucket-credentials
       namespace: flux-system
     type: Opaque
     stringData:

--- a/docs/main/04-guides/07-new-destination.mdx
+++ b/docs/main/04-guides/07-new-destination.mdx
@@ -59,7 +59,7 @@ Kratix reconcile the system. For that, you need to first create the new
 Kubernetes cluster:
 
 ```bash
-kind create cluster --image kindest/node:v1.27.3 --name worker-2
+kind create cluster --image kindest/node:v1.33.1 --name worker-2
 export WORKER_2="kind-worker-2"
 ```
 

--- a/docs/main/04-guides/07-new-destination.mdx
+++ b/docs/main/04-guides/07-new-destination.mdx
@@ -93,7 +93,7 @@ spec:
     kind: BucketStateStore
 ```
 
-The Destination will use the pre-existing MinIO [State Store](/main/reference/statestore/intro).
+The Destination will use the pre-existing SeaweedFS [State Store](/main/reference/statestore/intro).
 Apply the Destination document to the platform cluster:
 
 ```bash

--- a/docs/ske/01-installing-ske/01-preconfigured-install.mdx
+++ b/docs/ske/01-installing-ske/01-preconfigured-install.mdx
@@ -44,7 +44,7 @@ before continuing.
 
 If you're working in a shared or production-like environment, see the full
 [installation guide](/ske/installing-ske/intro) to avoid configuration
-conflicts. The  preconfigured installation deploys a local, insecure MinIO instance—intended
+conflicts. The  preconfigured installation deploys a local, insecure SeaweedFS instance—intended
 only for local development.
 
 ## Installation
@@ -146,7 +146,6 @@ NAME                                                       READY   STATUS      R
 backstage-84c6c6bc97-x9vp4                                 1/1     Running     0          48s
 backstage-controller-controller-manager-59f5dc86fd-dd8d7   1/1     Running     0          88s
 kratix-platform-controller-manager-57865f86c5-lp8bm        1/1     Running     0          88s
-minio-6c6bdc6456-hkw86                                     1/1     Running     0          88s
 ske-quick-start-installer-fmfbq                            0/1     Completed   0          113s
 
 ```
@@ -351,7 +350,7 @@ GitOps repository. In this case the workflow for the PostgreSQL Promise was
 quite simple, it took the users input and used this to generate the required
 Kubernetes resources to create the PostgreSQL instance. Those resources were
 then scheduled to the Platform via the GitOps repo (in this simple scenario, an
-in-cluster s3 compatible bucket using MinIO).
+in-cluster s3 compatible bucket using SeaweedFS).
 
 You can see the workflows that were run by inspecting the Pods:
 ```bash

--- a/docs/ske/10-integrations/09-portal-controller/02-backstage/06-development-image.mdx
+++ b/docs/ske/10-integrations/09-portal-controller/02-backstage/06-development-image.mdx
@@ -36,7 +36,7 @@ For more advanced or production-ready customization, see the [Configuring Backst
 Before you begin, ensure you have:
 
 - A running **Kubernetes cluster**
-- Access to an **S3-compatible bucket** (e.g., MinIO, GCS, or S3)
+- Access to an **S3-compatible bucket** (e.g., SeaweedFS, GCS, or S3)
 
 ---
 
@@ -99,7 +99,7 @@ data:
           secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
           # OPTIONAL: Modify to match the endpoint for your S3 compatible bucket.
           # The default setting works with the Kratix quick start setup: https://docs.kratix.io/ske/installing-ske/preconfigured-install
-          endpoint: 'http://minio.kratix-platform-system.svc.cluster.local'
+          endpoint: 'http://bucket.seaweedfs.svc.cluster.local'
           s3ForcePathStyle: true
     techdocs:
       builder: "local"
@@ -139,7 +139,7 @@ data:
             - allow: [User, Group]
       providers:
         awsS3:
-          kratix-minio:
+          kratix-bucket:
           # OPTIONAL: Modify to match your bucket name and configuration.
           # The default setting works with the Kratix quickstart setup: https://docs.kratix.io/ske/installing-ske/preconfigured-install
             bucketName: kratix
@@ -215,14 +215,14 @@ spec:
             secretKeyRef:
               # OPTIONAL: Modify to match the secret for access to your bucket.
               # The default setting works with the Kratix quick start setup: https://docs.kratix.io/ske/installing-ske/preconfigured-install
-              name: minio-credentials
+              name: bucket-credentials
               key: accessKeyID
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
               # OPTIONAL: Modify to match the secret for access to your bucket.
               # The default setting works with the Kratix quick start setup: https://docs.kratix.io/ske/installing-ske/preconfigured-install
-              name: minio-credentials
+              name: bucket-credentials
               key: secretAccessKey
         - name: SA_TOKEN
           valueFrom:

--- a/docs/ske/10-integrations/09-portal-controller/02-backstage/08-adapter-pipeline-stage.mdx
+++ b/docs/ske/10-integrations/09-portal-controller/02-backstage/08-adapter-pipeline-stage.mdx
@@ -185,7 +185,7 @@ Component Promise](/ske/integrations/backstage/reference/generator-promise). Oth
 in Backstage, and Backstage will emit a warning:
 
 ```
-{"level":"warn","message":"Detected conflicting entityRef component:default/my-request-jenkins already referenced by url:http://minio.kratix-platform-system.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure/5cfaf/backstage/catalog-info.yaml and now also url:http://minio.kratix-platform-system.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure-2/5cfaf/backstage/catalog-info.yaml","plugin":"catalog","service":"backstage"}
+{"level":"warn","message":"Detected conflicting entityRef component:default/my-request-jenkins already referenced by url:http://bucket.seaweedfs.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure/5cfaf/backstage/catalog-info.yaml and now also url:http://bucket.seaweedfs.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure-2/5cfaf/backstage/catalog-info.yaml","plugin":"catalog","service":"backstage"}
 ```
 
 ### Authenticating against the image registry

--- a/docs/ske/10-integrations/10-backstage/05-reference/01-generator.mdx
+++ b/docs/ske/10-integrations/10-backstage/05-reference/01-generator.mdx
@@ -152,7 +152,7 @@ Component Promise](./generator-promise). Otherwise, you will observe only one of
 in Backstage, and Backstage will emit a warning:
 
 ```
-{"level":"warn","message":"Detected conflicting entityRef component:default/my-request-jenkins already referenced by url:http://minio.kratix-platform-system.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure/5cfaf/backstage/catalog-info.yaml and now also url:http://minio.kratix-platform-system.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure-2/5cfaf/backstage/catalog-info.yaml","plugin":"catalog","service":"backstage"}
+{"level":"warn","message":"Detected conflicting entityRef component:default/my-request-jenkins already referenced by url:http://bucket.seaweedfs.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure/5cfaf/backstage/catalog-info.yaml and now also url:http://bucket.seaweedfs.svc.cluster.local/kratix/backstage/resources/default/cicd/my-request/instance-configure-2/5cfaf/backstage/catalog-info.yaml","plugin":"catalog","service":"backstage"}
 ```
 
 ### Authenticating against the image registry

--- a/docs/workshop/operating-kratix/01-installing-kratix.mdx
+++ b/docs/workshop/operating-kratix/01-installing-kratix.mdx
@@ -208,8 +208,8 @@ Type:  Opaque
 
 Data
 ====
-accessKeyID:      10 bytes
-secretAccessKey:  10 bytes
+accessKeyID:      11 bytes
+secretAccessKey:  11 bytes
 ```
 
 For further details on State Stores, check the [State Store documentation
@@ -320,15 +320,15 @@ bin/s5cmd ls "s3://kratix/*"
 The above command will give an output similar to:
 
 ```shell-session
-2024/01/01 15:00:00               116  worker-cluster/dependencies/kratix-canary-namespace.yaml
-2024/01/01 15:00:00               206  worker-cluster/resources/kratix-canary-configmap.yaml
+2026/08/19 12:55:17                90  worker-cluster/dependencies/kratix-canary-namespace.yaml
+2026/08/19 12:55:17               181  worker-cluster/resources/kratix-canary-configmap.yaml
 ```
 
 You can also inspect the contents of the test documents. For example, take the
 `kratix-canary-namespace.yaml`:
 
 ```bash
-mc cat kind/kratix/worker-cluster/dependencies/kratix-canary-namespace.yaml
+bin/s5cmd cat s3://kratix/worker-cluster/dependencies/kratix-canary-namespace.yaml
 ```
 
 The above command will give an output similar to:
@@ -337,7 +337,6 @@ The above command will give an output similar to:
 apiVersion: v1
 kind: Namespace
 metadata:
-  creationTimestamp: null
   name: kratix-worker-system
 spec: {}
 status: {}

--- a/docs/workshop/operating-kratix/01-installing-kratix.mdx
+++ b/docs/workshop/operating-kratix/01-installing-kratix.mdx
@@ -128,8 +128,8 @@ can write. When registering a Worker cluster with Kratix, you will need to
 specify the State Store you intend to use. Kratix will then write to the
 specified State Store when scheduling workloads for deployment on that cluster.
 
-Create a new State Store that points to the MinIO bucket created in the
-[prerequisites](../prerequisites/create-clusters#minio-as-the-gitops-repository):
+Create a new State Store that points to the SeaweedFS bucket created in the
+[prerequisites](../prerequisites/create-clusters#seaweedfs-as-the-gitops-repository):
 
 ```yaml
 cat << EOF | kubectl --context $PLATFORM apply -f -
@@ -138,11 +138,11 @@ kind: BucketStateStore
 metadata:
   name: default
 spec:
-  endpoint: minio.kratix-platform-system.svc.cluster.local
+  endpoint: bucket.seaweedfs.svc.cluster.local
   insecure: true
   bucketName: kratix
   secretRef:
-    name: minio-credentials
+    name: bucket-credentials
     namespace: default
 EOF
 ```
@@ -159,47 +159,47 @@ bucketstatestore.platform.kratix.io/default created
 The State Store document contains the configuration needed to access the actual
 backing storage.
 
-In the example above, you created a new `BucketStateStore` as a MinIO bucket
+In the example above, you created a new `BucketStateStore` as a SeaweedFS bucket
 has been provisioned for storage, but you could use any other S3-compatible
 storage like Amazon S3 and Google Cloud Storage.
 
 The `spec` includes the details needed to access that specific kind of State
 Store. On the example above, you configured the `endpoint` to the cluster
-address of the MinIO server you deployed on the platform cluster. Since MinIO
+address of the SeaweedFS server you deployed on the platform cluster. Since SeaweedFS
 is running in-cluster and without TLS enabled, it is necessary to set `insecure`
 to true.
 
-You can see the MinIO service on the `kratix-platform-system`:
+You can see the bucket service in the `seaweedfs` namespace:
 
 ```bash
-kubectl --context $PLATFORM --namespace kratix-platform-system get service minio
+kubectl --context $PLATFORM --namespace seaweedfs get service bucket
 ```
 
 The above command will give an output similar to:
 
 ```shell-session
-NAME    TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)        AGE
-minio   NodePort   10.96.96.166   <none>        80:31337/TCP   17h
+NAME     TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)        AGE
+bucket   NodePort   10.96.96.166   <none>        80:31337/TCP   17h
 ```
 
-`bucketName` refers to the actual bucket on the MinIO server. The bucket needs
-to exist prior to Kratix trying to use it. As a part of setting up MinIO you
-ran a Job to create the base `kratix` bucket.
+`bucketName` refers to the actual bucket on the SeaweedFS server. The bucket needs
+to exist prior to Kratix trying to use it. Setting up SeaweedFS created the base
+`kratix` bucket for you.
 
 Finally, `secretRef` points to a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/),
 in the same namespace as the State Store, containing the credentials to access
 the store. For `BucketStateStore`, Kratix expects to find an `accessKeyID` and
-a `secretAccessKey` when resolving the secret. As part of the MinIO deployment,
+a `secretAccessKey` when resolving the secret. As part of the SeaweedFS deployment,
 you also created the necessary Secret:
 
 ```bash
-kubectl --context $PLATFORM describe secret minio-credentials
+kubectl --context $PLATFORM describe secret bucket-credentials
 ```
 
 The above command will give an output similar to:
 
 ```shell-session
-Name:         minio-credentials
+Name:         bucket-credentials
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
@@ -311,17 +311,17 @@ In fact, as soon as a new Destination is registered, Kratix writes a test
 document to the State Store. You can use this test to validate that the entire
 system is wired up correctly.
 
-First, check the MinIO `kratix` bucket:
+First, check the `kratix` bucket:
 
 ```bash
-mc ls -r kind
+bin/s5cmd ls "s3://kratix/*"
 ```
 
 The above command will give an output similar to:
 
 ```shell-session
-[2024-01-01 15:00:00 GMT]   116B STANDARD kratix/worker-cluster/dependencies/kratix-canary-namespace.yaml
-[2024-01-01 15:00:00 GMT]   206B STANDARD kratix/worker-cluster/resources/kratix-canary-configmap.yaml
+2024/01/01 15:00:00               116  worker-cluster/dependencies/kratix-canary-namespace.yaml
+2024/01/01 15:00:00               206  worker-cluster/resources/kratix-canary-configmap.yaml
 ```
 
 You can also inspect the contents of the test documents. For example, take the
@@ -380,7 +380,7 @@ Your platform is ready to receive Promises! Well done!
 To recap the steps you took:
 
 1. ✅&nbsp;&nbsp;Installed Kratix on the platform cluster
-1. ✅&nbsp;&nbsp;Told Kratix about the MinIO bucket, as a Bucket State Store
+1. ✅&nbsp;&nbsp;Told Kratix about the SeaweedFS bucket, as a Bucket State Store
 1. ✅&nbsp;&nbsp;Told Kratix about the worker cluster, as a Destination
 
 ## 🎉 Congratulations

--- a/docs/workshop/operating-kratix/02-installing-a-promise.mdx
+++ b/docs/workshop/operating-kratix/02-installing-a-promise.mdx
@@ -26,7 +26,7 @@ This is Part 2 of [a series](intro) illustrating how Kratix works. <br />
 
 Following the [Installing Kratix](installing-kratix) tutorial, you should now
 have Kratix up and running in your platform cluster. You should also have a
-worker cluster reconciling on the documents in the MinIO Bucket.
+worker cluster reconciling on the documents in the SeaweedFS Bucket.
 
 Validate your installation by running:
 
@@ -39,7 +39,6 @@ The above command will give an output similar to:
 ```shell-session
 NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
 kratix-platform-controller-manager   1/1     1            1           1h
-minio                                1/1     1            1           1h
 ```
 
 You should also have a `kratix-worker-system` namespace in your worker cluster:

--- a/docs/workshop/prerequisites/01-setup.mdx
+++ b/docs/workshop/prerequisites/01-setup.mdx
@@ -41,7 +41,7 @@ tools:
 
 1. An **S3 CLI** for inspecting the state store bucket: <br /> the Kratix repository ships one,
    so there is nothing to install separately&mdash;`make s5cmd-cli` puts a preconfigured
-   [`s5cmd`](https://github.com/peak/s5cmd) at `bin/s5cmd`, already pointed at the local
+   [`s5cmd`](https://github.com/coreweave/s5cmd) at `bin/s5cmd`, already pointed at the local
    bucket. <br /> If you would rather use your own S3 client, `make bucket-env` prints the
    endpoint and credentials to export.
 

--- a/docs/workshop/prerequisites/01-setup.mdx
+++ b/docs/workshop/prerequisites/01-setup.mdx
@@ -39,8 +39,11 @@ tools:
 
    :::
 
-1. `mc` / **MinIO Client**: <br /> The CLI for MinIO&mdash;allows you to run commands against MinIO clusters. <br
-   /> See [the install guide](https://docs.min.io/community/minio-object-store/).
+1. An **S3 CLI** for inspecting the state store bucket: <br /> the Kratix repository ships one,
+   so there is nothing to install separately&mdash;`make s5cmd-cli` puts a preconfigured
+   [`s5cmd`](https://github.com/peak/s5cmd) at `bin/s5cmd`, already pointed at the local
+   bucket. <br /> If you would rather use your own S3 client, `make bucket-env` prints the
+   endpoint and credentials to export.
 
 1. `git` / **Git**: <br /> The CLI for Git&mdash;allows you to clone the Kratix repository. <br
    /> See [the install guide](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).

--- a/docs/workshop/prerequisites/02-create-clusters.mdx
+++ b/docs/workshop/prerequisites/02-create-clusters.mdx
@@ -166,18 +166,17 @@ seaweedfs   1/1     1            1           1h
 
 The bucket is created by a helper container in the same Pod as the SeaweedFS
 server, and the Pod does not report `Ready` until the bucket exists. So a ready
-Deployment already tells you the bucket is there&mdash;there is no separate Job to
-wait for:
+Deployment already tells you the bucket is there:
 
 ```bash
 kubectl --context $PLATFORM wait pod --namespace seaweedfs \
   --selector run=seaweedfs --for=condition=ready --timeout=120s
 ```
 
-To look inside the bucket, use the S3 CLI the Kratix repository ships:
+To look inside the bucket, use the `s5cmd` utility provided in the Kratix repository:
 
 ```bash
-# downloads a preconfigured s5cmd to bin/s5cmd; nothing to export
+# downloads s5cmd and provides a convenience wrapper for easy access
 make s5cmd-cli
 
 # list the buckets

--- a/docs/workshop/prerequisites/02-create-clusters.mdx
+++ b/docs/workshop/prerequisites/02-create-clusters.mdx
@@ -128,69 +128,66 @@ cert-manager-cainjector-bdd866bd4-7d8zp   1/1     Running   0          19s
 cert-manager-webhook-5655dcfb4b-54r49     1/1     Running   0          19s
 ```
 
-### MinIO as the GitOps Repository
+### SeaweedFS as the GitOps Repository
 
 As mentioned before, Kratix leverages GitOps for deploying and reconciling
 scheduled workloads. That means that Kratix needs a backing service to serve
 as the state store. Kratix supports two types of state stores: S3-compatible
-buckets and Git repositories. In our workshops, you will use a MinIO instance
+buckets and Git repositories. In our workshops, you will use a SeaweedFS instance
 running in the Platform cluster as the state store. In production environments,
 you will probably use a Git repository or a S3-compatible bucket in a Cloud
 Provider.
 
-To install MinIO in the Platform cluster, run:
+To install SeaweedFS in the Platform cluster, run:
 
 ```bash
 # from the root of the Kratix repository
-kubectl --context $PLATFORM apply --filename config/samples/minio-install.yaml
+kubectl --context $PLATFORM apply --filename config/samples/seaweedfs-install.yaml
 ```
 
 The above command will:
 
-- Deploy an instance of MinIO on the `kratix-platform-system` namespace
-- Create a Secret with the MinIO credentials
-- Run a Job to create a bucket called `kratix` on the MinIO instance. <br />
+- Deploy an instance of SeaweedFS in its own `seaweedfs` namespace
+- Create a Secret called `bucket-credentials` with the bucket credentials
+- Create a bucket called `kratix` on the SeaweedFS instance
 
 You can verify the installation by running:
 
 ```bash
-kubectl --context $PLATFORM get deployments --namespace kratix-platform-system
+kubectl --context $PLATFORM get deployments --namespace seaweedfs
 ```
 
 The above command will give an output similar to:
 
 ```shell-session
-NAME     READY   UP-TO-DATE   AVAILABLE   AGE
-minio    1/1     1            1           1h
+NAME        READY   UP-TO-DATE   AVAILABLE   AGE
+seaweedfs   1/1     1            1           1h
 ```
 
-You can also verify the `Create Bucket` job:
+The bucket is created by a helper container in the same Pod as the SeaweedFS
+server, and the Pod does not report `Ready` until the bucket exists. So a ready
+Deployment already tells you the bucket is there&mdash;there is no separate Job to
+wait for:
 
 ```bash
-kubectl --context $PLATFORM get jobs
+kubectl --context $PLATFORM wait pod --namespace seaweedfs \
+  --selector run=seaweedfs --for=condition=ready --timeout=120s
 ```
 
-The above command will give an output similar to:
-
-```shell-session
-NAME                  COMPLETIONS   DURATION   AGE
-minio-create-bucket   1/1           3m5s       1h
-```
-
-Once the Job completes, you should be able to see the `kratix` bucket in the MinIO instance using the `mc` CLI:
+To look inside the bucket, use the S3 CLI the Kratix repository ships:
 
 ```bash
-# configure the mc CLI to use the MinIO instance
-mc alias set kind http://localhost:31337 minioadmin minioadmin
+# downloads a preconfigured s5cmd to bin/s5cmd; nothing to export
+make s5cmd-cli
 
 # list the buckets
-mc ls kind/
+bin/s5cmd ls
 ```
 
 The above command will give an output similar to:
 
 ```shell-session
-[2025-12-02 15:10:00 CEST]     0B kratix/
+2025/12/02 15:10:00  kratix
 ```
 
 You platform cluster is now ready to receive Kratix!
@@ -205,7 +202,7 @@ designated State Store. When it comes to reconciling the declared state on the
 Destination cluster, Kratix remains agnostic about the specific tool to be used
 on the clusters. In this tutorial, you will utilise [Flux](https://fluxcd.io/)
 on the Destination cluster, and configure it to reconcile the state from the
-MinIO bucket.
+SeaweedFS bucket.
 
 To install and configure Flux, run the following script from the Kratix
 repository:
@@ -238,7 +235,7 @@ Install Flux on the Worker cluster:
 kubectl --context $WORKER apply --filename https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml
 ```
 
-Next, Flux must be configured to read from the MinIO bucket. For that, you
+Next, Flux must be configured to read from the SeaweedFS bucket. For that, you
 will create a new Flux [Bucket Source](https://fluxcd.io/flux/components/source/buckets/),
 together with a Secret containing the bucket credentials.
 
@@ -247,7 +244,7 @@ together with a Secret containing the bucket credentials.
 You may notice that the value of the Bucket `endpoint` on the document below is
 set to `172.18.0.2:31337`.
 
-Flux now needs to access MinIO _across_ clusters, so you will need to use
+Flux now needs to access SeaweedFS _across_ clusters, so you will need to use
 an externally available endpoint.
 
 `172.18.0.2` will often be the address of the platform cluster running on KinD.
@@ -267,17 +264,17 @@ If the command above outputs a different IP, make sure to update the Bucket
 configuration below accordingly.
 
 The port part of the endpoint should always be 31337. Verify the NodePort of the
-MinIO service in the Platform cluster:
+SeaweedFS service in the Platform cluster:
 
 ```bash
-kubectl --context $PLATFORM get services minio --namespace kratix-platform-system
+kubectl --context $PLATFORM get services bucket --namespace seaweedfs
 ```
 
 The above command will give an output similar to:
 
 ```shell-session
-NAME    TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
-minio   NodePort   10.96.45.28   <none>        80:31337/TCP   1h
+NAME     TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+bucket   NodePort   10.96.45.28   <none>        80:31337/TCP   1h
 ```
 
 :::
@@ -290,12 +287,12 @@ cat <<EOF | kubectl --context $WORKER apply -f -
 apiVersion: v1
 kind: Secret
 metadata:
-  name: minio-credentials
+  name: bucket-credentials
   namespace: flux-system
 type: Opaque
 stringData:
-  accesskey: minioadmin
-  secretkey: minioadmin
+  accesskey: kratixadmin
+  secretkey: kratixadmin
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: Bucket
@@ -309,14 +306,14 @@ spec:
   endpoint: 172.18.0.2:31337 # make sure to read the caution box above
   insecure: true
   secretRef:
-    name: minio-credentials
+    name: bucket-credentials
 EOF
 ```
 
 The above command will give an output similar to:
 
 ```shell-session
-secret/minio-credentials created
+secret/bucket-credentials created
 bucket.source.toolkit.fluxcd.io/kratix created
 ```
 

--- a/docs/workshop/prerequisites/02-create-clusters.mdx
+++ b/docs/workshop/prerequisites/02-create-clusters.mdx
@@ -49,7 +49,7 @@ kind delete clusters --all
 
 kind create cluster \
     --name platform \
-    --image kindest/node:v1.27.3 \
+    --image kindest/node:v1.33.1 \
     --config config/samples/kind-platform-config.yaml
 ```
 
@@ -70,7 +70,7 @@ Create the **Worker** cluster with the following command:
 ```bash
 kind create cluster \
     --name worker \
-    --image kindest/node:v1.27.3 \
+    --image kindest/node:v1.33.1 \
     --config config/samples/kind-worker-config.yaml
 ```
 
@@ -187,7 +187,7 @@ bin/s5cmd ls
 The above command will give an output similar to:
 
 ```shell-session
-2025/12/02 15:10:00  kratix
+2026/08/19 12:42:29  s3://kratix
 ```
 
 You platform cluster is now ready to receive Kratix!

--- a/docs/workshop/writing-a-promise/20-promise-workflows.mdx
+++ b/docs/workshop/writing-a-promise/20-promise-workflows.mdx
@@ -215,8 +215,8 @@ docker run \
     --volume ${outputDir}:/kratix/output \
     --volume ${inputDir}:/kratix/input \
     --volume ${metadataDir}:/kratix/metadata \
-    --env MINIO_USER=minioadmin \
-    --env MINIO_PASSWORD=minioadmin \
+    --env MINIO_USER=kratixadmin \
+    --env MINIO_PASSWORD=kratixadmin \
     --env MINIO_ENDPOINT=localhost:31337 \
     kratix-workshop/app-pipeline-image:v1.0.0 sh -c "$command"
 EOF

--- a/docs/workshop/writing-a-promise/30-secrets-and-state.mdx
+++ b/docs/workshop/writing-a-promise/30-secrets-and-state.mdx
@@ -25,13 +25,13 @@ You will:
 * [Learn how to store and reuse state between runs](#state)
 
 To illustrate the concepts above, you will be updating your Promise so that it
-creates a bucket in the MinIO server that's deployed in your Platform cluster.
+creates a bucket in the SeaweedFS server that's deployed in your Platform cluster.
 You will create the bucket using `terraform`.
 
 ## Secrets
 
 A common need for Workflows is to access secrets. In your Promise, you will need
-access to the MinIO credentials to be able to create a bucket. You could pull
+access to the SeaweedFS credentials to be able to create a bucket. You could pull
 the credentials in different ways, but the Kratix Pipeline kind provides a
 convenient way to access secrets, similar to how you would access Secrets in a
 Kubernetes Pod.
@@ -43,13 +43,13 @@ cat <<EOF | kubectl --context $PLATFORM apply -f -
 apiVersion: v1
 kind: Secret
 metadata:
-  name: app-promise-minio-creds
+  name: app-promise-bucket-creds
   namespace: default
 type: Opaque
 stringData:
-  username: minioadmin
-  password: minioadmin
-  endpoint: minio.kratix-platform-system.svc.cluster.local
+  username: kratixadmin
+  password: kratixadmin
+  endpoint: bucket.seaweedfs.svc.cluster.local
 EOF
 ```
 
@@ -85,17 +85,17 @@ spec:
                   - name: MINIO_ENDPOINT
                     valueFrom:
                       secretKeyRef:
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                         key: endpoint
                   - name: MINIO_USER
                     valueFrom:
                       secretKeyRef:
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                         key: username
                   - name: MINIO_PASSWORD
                     valueFrom:
                       secretKeyRef:
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                         key: password
           #highlight-end
 status: {}
@@ -171,7 +171,7 @@ With that change in place, you can run the test script:
 ./scripts/test-pipeline create-bucket
 ```
 
-If everything works well, you should see a new bucket created in your MinIO
+If everything works well, you should see a new bucket created in your SeaweedFS
 server:
 
 ```bash
@@ -365,7 +365,7 @@ import FullPromise from "!!raw-loader!./_partials/secrets-and-state/04-full-prom
 
 As soon as the Promise is applied, Kratix will trigger an update for the
 existing application. Once the pipeline completes, you should see a new Bucket
-on your MinIO server:
+on your SeaweedFS server:
 
 ```bash
 mc ls kind/

--- a/docs/workshop/writing-a-promise/30-secrets-and-state.mdx
+++ b/docs/workshop/writing-a-promise/30-secrets-and-state.mdx
@@ -175,14 +175,14 @@ If everything works well, you should see a new bucket created in your SeaweedFS
 server:
 
 ```bash
-mc ls kind/
+bin/s5cmd ls
 ```
 
 The output should look like this:
 
 ```shell-session
-[2024-01-26 15:33:03 GMT]     0B kratix/
-[2024-01-31 11:44:55 GMT]     0B my-app.default/
+2026/08/19 12:42:29  s3://kratix
+2026/08/19 12:55:41  s3://my-app.default
 ```
 
 Great! That proves our pipeline stage works end-to-end. But what happens if you
@@ -293,14 +293,14 @@ You should see from the logs that the bucket got created and that the state got
 persisted in a ConfigMap. You can validate with the following command:
 
 ```bash
-mc ls kind/
+bin/s5cmd ls
 ```
 
 The above command should show you the buckets, like last time:
 
 ```shell-session
-[2024-01-26 15:33:03 GMT]     0B kratix/
-[2024-01-31 11:44:55 GMT]     0B my-app.default/
+2026/08/19 12:42:29  s3://kratix
+2026/08/19 12:55:41  s3://my-app.default
 ```
 
 As for the ConfigMap, you can retrieve it with the following command:
@@ -368,15 +368,15 @@ existing application. Once the pipeline completes, you should see a new Bucket
 on your SeaweedFS server:
 
 ```bash
-mc ls kind/
+bin/s5cmd ls
 ```
 
 The output should look like this:
 
 ```shell-session
-[2024-01-26 15:33:03 GMT]     0B kratix/
-[2024-01-31 11:44:55 GMT]     0B my-app.default/
-[2024-01-31 11:44:55 GMT]     0B todo.default/
+2026/08/19 12:42:29  s3://kratix
+2026/08/19 12:55:41  s3://my-app.default
+2026/08/19 13:02:18  s3://todo.default
 ```
 
 You should also see the ConfigMap for the todo app:

--- a/docs/workshop/writing-a-promise/_partials/compound-promise/01-full-promise.yaml
+++ b/docs/workshop/writing-a-promise/_partials/compound-promise/01-full-promise.yaml
@@ -78,17 +78,17 @@ spec:
                     valueFrom:
                       secretKeyRef:
                         key: endpoint
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                   - name: MINIO_USER
                     valueFrom:
                       secretKeyRef:
                         key: username
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                   - name: MINIO_PASSWORD
                     valueFrom:
                       secretKeyRef:
                         key: password
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                 image: kratix-workshop/app-pipeline-image:v1.0.0
                 name: create-bucket
               - name: database-configure

--- a/docs/workshop/writing-a-promise/_partials/secrets-and-state/04-full-promise.yaml
+++ b/docs/workshop/writing-a-promise/_partials/secrets-and-state/04-full-promise.yaml
@@ -77,16 +77,16 @@ spec:
                   - name: MINIO_ENDPOINT
                     valueFrom:
                       secretKeyRef:
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                         key: endpoint
                   - name: MINIO_USER
                     valueFrom:
                       secretKeyRef:
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                         key: username
                   - name: MINIO_PASSWORD
                     valueFrom:
                       secretKeyRef:
-                        name: app-promise-minio-creds
+                        name: app-promise-bucket-creds
                         key: password
 status: {}


### PR DESCRIPTION
## Description
This relates to issue https://github.com/syntasso/kratix-private/issues/195 and changes all references to Minio to point to SeaweedFS instead. It includes documentation for Kratix OSS, SKE, and workshop setup procedures.


## Checklist

* [ ] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?
