### PR TITLE
docs(ske): add v0.56.0 release notes

### DIFF
--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,6 +19,16 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
+### [v0.56.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.56.0/) (TBD)
+
+#### Features
+
+* Kratix now re-runs promise and resource workflows after a failure, ensuring they always converge rather than remaining in a failed state.
+
+#### Maintenance
+
+* Base image updates and package maintenance.
+
 ### [v0.55.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.55.0/) (2026-08-12)
 
 #### Features

--- a/docs/ske/50-releases/10-ske.mdx
+++ b/docs/ske/50-releases/10-ske.mdx
@@ -19,7 +19,7 @@ Check the release notes below for information on each available version.
 
 ## Release Notes
 
-### [v0.56.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.56.0/) (TBD)
+### [v0.56.0](http://syntasso-enterprise-releases.s3-website.eu-west-2.amazonaws.com/#ske/v0.56.0/) (2026-08-19)
 
 #### Features
 


### PR DESCRIPTION
## Summary

Release notes for SKE v0.56.0.

**Included in `10-ske.mdx`:**
- Kratix (submodule): promise and resource workflows now re-run after a failure — `feat: reconcile promise and resource workflows after failure (#866)`

**Excluded:**
- Portal/Cortex fixes (kirederik) — ske-portal-controller image is not in `ske-distribution.yaml` for this release
- ske-operator dry-run feature flag (ChunyiLyu) — maps to `20-platform/10-ske-operator.mdx` (ske-operator v0.33.0 component page)
- Chainguard base image bumps — captured under Maintenance
- CI/infra changes — not documented in release notes

## Merge order

1. Promote the release (wait for full tag on enterprise-kratix)
2. Merge this PR last
3. **Before merging**: replace `(TBD)` with the promotion date in `YYYY-MM-DD` format