### PR TITLE
docs(portal-patch): document insertBefore and insertAfter

### DIFF
--- a/docs/ske/10-integrations/09-portal-controller/04-customization/00-intro.mdx
+++ b/docs/ske/10-integrations/09-portal-controller/04-customization/00-intro.mdx
@@ -23,7 +23,7 @@ image, or the helper described below.
 :::tip
 If you would rather not write a container, [Portal Patch](./portal-patch/intro) is a helper image
 we ship that applies declarative recipes in this lane, covering setting owners and tags, removing
-form fields, and reshaping Cortex workflows. It is entirely optional, and you can mix it with your
+form fields, adding an item to a generated list, and reshaping Cortex workflows. It is entirely optional, and you can mix it with your
 own containers in the same pipeline.
 :::
 

--- a/docs/ske/10-integrations/09-portal-controller/04-customization/01-portal-patch.mdx
+++ b/docs/ske/10-integrations/09-portal-controller/04-customization/01-portal-patch.mdx
@@ -18,8 +18,8 @@ being present.
 Use it because it saves you writing a script, not because you have to.
 :::
 
-For the common cases, setting an owner, adding tags, removing a form field, reshaping a Cortex
-workflow, a recipe is shorter than the equivalent script, is order-independent, and fails loudly
+For the common cases, setting an owner, adding tags, removing a form field, adding a step beside
+an existing one, reshaping a Cortex workflow, a recipe is shorter than the equivalent script, is order-independent, and fails loudly
 instead of silently producing the wrong document. For anything it cannot express, write your own
 container as described in [Customization](../customization).
 
@@ -121,6 +121,7 @@ document that looks fine and is wrong.
 | Use a recipe when | Write your own container when |
 |---|---|
 | Setting or removing fields on the generated documents | You need to read the parent object to derive a value |
+| Adding a step, link or workflow input beside an existing one | You need to build a list whose contents depend on the request |
 | Adding or replacing tags, owners, lifecycle, titles | You need to call an external service |
 | Removing or reshaping a form field on a Backstage Template | You need logic a declarative patch cannot express |
 | Projecting an entity attribute in a Cortex workflow | You are generating entirely new files |

--- a/docs/ske/10-integrations/09-portal-controller/04-customization/02-recipe-reference.mdx
+++ b/docs/ske/10-integrations/09-portal-controller/04-customization/02-recipe-reference.mdx
@@ -29,8 +29,8 @@ patch:                 # required for merge, forbidden for every other op
 | `target.kind` | string | all | Selects the document whose top-level `kind` matches. Mutually exclusive with `target.file`. |
 | `target.file` | string | all | Selects a single-document file by bare filename. Mutually exclusive with `target.kind`. |
 | `target.list` | object or list | all | Selects an item, or a chain of nested items, within the document. |
-| `op` | string | all | `merge` (default), `remove`, `singleSpecPage`, `cortexEntityProjection`, `hideNamespaceManifest`. |
-| `patch` | map | `merge` | The changes to merge. Required for `merge`, rejected for every other operation. |
+| `op` | string | all | `merge` (default), `remove`, `insertBefore`, `insertAfter`, `singleSpecPage`, `cortexEntityProjection`, `hideNamespaceManifest`. |
+| `patch` | map | `merge`, `insertBefore`, `insertAfter` | The changes to merge, or the item to insert. Required for `merge`, `insertBefore` and `insertAfter`, rejected for every other operation. |
 | `field` | string | `cortexEntityProjection`, `hideNamespaceManifest` | Dot-separated path to a string field inside the selected item. |
 | `sourceAction` | string | `cortexEntityProjection` | The Cortex action producing the output. |
 | `outputKey` | string | `cortexEntityProjection` | The output key on that action. |
@@ -102,6 +102,10 @@ target:
       value: app
 ```
 
+The operation applies to the item the **last** selector names; every selector before it only
+descends. For `insertBefore` and `insertAfter`, that last item is the anchor, and the new item
+joins the list holding it.
+
 ## Operations
 
 ### `merge` (default)
@@ -157,6 +161,88 @@ op: remove
 ```
 
 To remove a field *within* an item rather than the item itself, use a `merge` with a `null` value.
+
+### `insertBefore` and `insertAfter`
+
+Adds `patch` to the selected list as a new item, immediately before or after the item the selector
+resolved to. The two operations differ in nothing else. Both require `target.list`, naming the
+**anchor** the new item sits beside, and a `patch`, which is the item to insert.
+
+Requires `ghcr.io/syntasso/portal-patch:0.8.0` or later.
+
+```yaml
+target:
+  kind: Template
+  list:
+    path: spec.steps
+    key: id
+    value: ske-configure-resource
+op: insertAfter
+patch:
+  id: notify
+  name: Notify the team
+  action: ske:notify
+  input:
+    message: a resource was requested
+```
+
+Without these operations, adding one scaffolder step, one catalogue link or one Cortex workflow
+input means restating the whole array in a `merge` patch, because a list in `patch` replaces the
+target list wholesale. That restated array is a copy of what the generate stage produced, and it
+goes stale silently: the next generator change adds a step the copy does not have, the recipe
+still applies, and the new step disappears with no error. An insert names only the item it adds
+and the sibling it sits beside, so there is nothing to go stale.
+
+Both operations work on Cortex documents too. With a chain of selectors, the anchor is the item
+the last selector names, which is how one workflow input is added beside another without
+restating the action's `inputs` list:
+
+```yaml
+target:
+  file: workflow-create.yaml
+  list:
+    - path: actions
+      key: slug
+      value: user-input
+    - path: schema.inputs
+      key: key
+      value: app
+op: insertAfter
+patch:
+  name: region
+  key: region
+  type: INPUT_FIELD
+  required: false
+```
+
+Behaviour:
+
+- **The anchor is selected by key, never by index**, like every other `target.list` selector, so
+  the generate stage reordering the list still lands the new item beside the right sibling.
+- **`patch` is the inserted item, verbatim.** Nothing is merged into it and the anchor is left
+  exactly as the generate stage wrote it. The `null` sentinel has no meaning here: `if: null` in an
+  insert's `patch` inserts a key whose value is null, it does not delete a key.
+- **Only a list of maps can be inserted into.** The selector matches by reading a key off a map
+  item, and `patch` is itself a map. Lists of strings, such as `metadata.tags` or a parameter
+  page's `required`, offer nothing to anchor on and stay restate-only.
+- **A `patch` that repeats the anchor selector's own key and value is rejected** at parse time,
+  because it would leave that selector matching two items. This is the usual result of copying the
+  anchor's YAML as a starting point and forgetting to change the `id`. A duplicate under any other
+  key is accepted, and the recipe that then fails is a later one selecting on that key.
+
+Choose an anchor that is always present. Two common anchors are conditional:
+
+- `spec.output.links` on a Template exists in `pull-request` [delivery
+  mode](../backstage/delivery-modes) only, and delivery mode is set on the connection, not on the
+  `PortalCustomization`, so the same recipe can work on one connection and fail the batch on
+  another. Every generated Component carries exactly one `metadata.links` entry, titled `Support`,
+  which is a mode-independent anchor for adding a link.
+- Per-property `spec.parameters` pages disappear when the pages are collapsed, either by a
+  [`singleSpecPage`](#singlespecpage) recipe or by `--single-spec-page` in the connection's
+  adapter arguments, so an anchor on a per-property page's title then matches nothing. It fails
+  the other way too: a page you insert that nests its fields under `properties.spec` is absorbed
+  by a **later** `singleSpecPage`, which judges a page by that structure alone. To keep a page of
+  your own beside `Specification`, do not nest it under `properties.spec`.
 
 ### `singleSpecPage`
 
@@ -250,6 +336,9 @@ The common ones:
 | `list selector key=K value=V is ambiguous` | More than one item matches |
 | `target.list path "P": "S" not found` | A path segment does not exist |
 | `missing or empty patch` | A `merge` recipe with no `patch` |
+| `op: insertBefore requires target.list` | An insert with no anchor |
+| `op: insertAfter requires a patch (the item to insert)` | An insert with nothing to insert |
+| `patch sets K: "V", the same key and value the anchor selector matches` | The inserted item duplicates the anchor's own selector key and value |
 | `unknown op "X"` | Misspelled operation |
 | `field "F" has no ... placeholder` | The field exists but does not contain the expected placeholder |
 
@@ -262,6 +351,8 @@ generate stage wrote them.
 |---|---|---|
 | `merge` | yes | yes |
 | `remove` | yes | yes |
+| `insertBefore` | yes | yes |
+| `insertAfter` | yes | yes |
 | `singleSpecPage` | yes | no |
 | `hideNamespaceManifest` | yes, `push` mode only | no |
 | `cortexEntityProjection` | no | yes |


### PR DESCRIPTION
## Description

Documents the new `insertBefore` / `insertAfter` recipe operations from
https://github.com/syntasso/enterprise-kratix/issues/1360.

In the [Recipe reference](docs/ske/10-integrations/09-portal-controller/04-customization/02-recipe-reference.mdx):

* New `insertBefore` and `insertAfter` operation section: what they do, why an insert beats
  restating the array, a Backstage step example and a Cortex nested-chain example, the
  patch-is-verbatim / list-of-maps-only / duplicate-anchor-key rules, and the two conditional
  anchors (`spec.output.links` is `pull-request` mode only; per-property spec pages disappear
  under `singleSpecPage`).
* The chain section now says the operation applies to the item the last selector names, and that
  an insert anchors there.
* `op` and `patch` rows in the top-level fields table, three rows in the errors table, and both
  ops in the portal support table.

Plus a mention of adding an item in the Portal Patch overview and the Customization tip.

**Note on versions:** the ops ship in `portal-patch:0.8.0`, which is not released yet. The new
section states `Requires ghcr.io/syntasso/portal-patch:0.8.0 or later`, and the existing `0.7.0`
examples across the docs are left alone. Release notes are not in this PR.

`docusaurus build` passes.

## Checklist

* [x] Is this PR about a feature in an upcoming SKE release?
* [ ] Have you cut that new SKE release?
* [ ] Have you updated the release notes?