### PR TITLE
docs(ske): document x-kratix-immutable on the Backstage Template

### DIFF
--- a/docs/ske/10-integrations/09-portal-controller/02-backstage/09-entity-yaml-format.mdx
+++ b/docs/ske/10-integrations/09-portal-controller/02-backstage/09-entity-yaml-format.mdx
@@ -56,6 +56,63 @@ spec:
   type: kratix-resource
 ```
 
+### Immutable spec fields
+
+A CRD can declare a field immutable, and the API server will reject any request that changes
+it. Backstage cannot see the CRD, so the generator carries that fact into the Template: for
+every spec property the CRD marks immutable, the generated parameter gains
+`x-kratix-immutable: true`.
+
+Given a Promise API field declared immutable with a
+[CEL validation rule](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules):
+
+```yaml
+serialNumber:
+  description: Serial number of the device
+  type: string
+  x-kubernetes-validations:
+    - rule: self == oldSelf
+      message: serialNumber is immutable
+```
+
+the Template's parameters carry:
+
+```yaml
+serialNumber:
+  description: Serial number of the device
+  title: SerialNumber
+  type: string
+  x-kratix-immutable: true
+```
+
+The keyword is a plain JSON Schema annotation, not a `ui:` key. One Template serves both
+creating and updating a resource, and a `ui:` key would apply to both, whereas an immutable
+field must be editable on create and locked only on update. The SKE frontend plugin reads the
+keyword to disable the field on the update form.
+
+Its absence means mutable. Nothing else about the property changes, and a Promise whose API
+declares no immutability rules produces exactly the Template it did before.
+
+#### Which rules are recognised
+
+The rule must be the whole-field comparison on its own. Spacing and operand order do not
+matter, so `self == oldSelf`, `self==oldSelf` and `oldSelf == self` are all recognised.
+
+Anything else is treated as mutable and the field stays editable, including several rules that
+do make the field immutable. Deciding those would mean evaluating CEL, which the generator does
+not do:
+
+| Rule | Marked | Why |
+| --- | --- | --- |
+| `self == oldSelf` | yes | the whole field is frozen |
+| `self.env == oldSelf.env` | no | freezes one child across a transition, so the API server still accepts changes to both. Declare the rule on `env` itself to have `env` locked |
+| `self == oldSelf && self != ''` | no | frozen, but the comparison is one conjunct of several |
+| `!oldSelf.hasValue() \|\| self == oldSelf.value()` | no | frozen once set, via `optionalOldSelf` ratcheting |
+| `(self == oldSelf)`, `!(self != oldSelf)` | no | frozen, written in a form the generator does not read |
+
+Writing the rule on a parent is the more familiar idiom in Kubernetes, so it is worth
+restating: to have a field locked in the form, put the rule on that field.
+
 ## The Kratix Catalog Entities
 
 The front-end plugin provides specific entity pages for both Kratix Promises and Kratix


### PR DESCRIPTION
Documents `x-kratix-immutable`, the keyword the portal controller's Backstage generator now emits for every spec property the Promise's CRD declares immutable.

Code PR: syntasso/enterprise-kratix#1386. Issue: syntasso/enterprise-kratix#1371. The consumer that acts on the keyword is syntasso/backstage#348.

Backstage builds its update form from the generated Template and never sees the CRD, so without this the form offers fields the API server will reject. The keyword is the only way the form can know.

The more useful half of the page is the table of rules that are **not** recognised. Several of them do make the field immutable, and the generator still reports mutable because deciding them would mean evaluating CEL:

- `self == oldSelf && <anything>` — frozen, but the comparison is one conjunct of several
- `!oldSelf.hasValue() || self == oldSelf.value()` — frozen once set, via `optionalOldSelf` ratcheting
- `(self == oldSelf)`, `!(self != oldSelf)` — frozen, written in a form the generator does not read

Failing that way is safe: the field stays editable and the API server rejects the change as it does today. syntasso/enterprise-kratix#1383 tracks recognising them.

The page also restates that a rule on a *parent* (`self.env == oldSelf.env`) constrains the transition rather than the field, so neither is marked. That is the more familiar Kubernetes idiom and it is what `ske-platform-manager` itself uses, so a Promise author is likely to reach for it and get no lock.

`yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
